### PR TITLE
Feature/find cluster

### DIFF
--- a/bin/scanpy-find-cluster.py
+++ b/bin/scanpy-find-cluster.py
@@ -22,6 +22,10 @@ def main(args):
 
     write_output_object(adata, args.output_object_file, args.output_format)
 
+    if args.output_text_file:
+        adata.obs[[args.key_added]].reset_index(level=0).rename(columns={'index':'cells'}).to_csv(
+            args.output_text_file, sep='\t', index=None)
+
     logging.info('Done')
     return 0
 
@@ -30,6 +34,9 @@ if __name__ == '__main__':
     argparser = ScanpyArgParser('Run Louvain clustering on data with neighborhood graph computed')
     argparser.add_input_object()
     argparser.add_output_object()
+    argparser.add_argument('--output-text-file',
+                           default=None,
+                           help='File name in which to store text format set of clusters')
     argparser.add_argument('--flavor',
                            choices=['vtraag', 'igraph'],
                            default='vtraag',

--- a/bin/scanpy-find-cluster.py
+++ b/bin/scanpy-find-cluster.py
@@ -1,0 +1,63 @@
+#!/usr/bin/env python
+
+from __future__ import print_function
+import logging
+from scanpy_wrapper_utils import ScanpyArgParser, comma_separated_list
+from scanpy_wrapper_utils import read_input_object, write_output_object
+
+
+def main(args):
+    logging.debug(args)
+    import scanpy.api as sc
+
+    adata = read_input_object(args.input_object_file, args.input_format)
+
+    sc.tl.louvain(adata,
+                  flavor=args.flavor,
+                  resolution=args.resolution,
+                  restrict_to=args.restrict_to,
+                  key_added=args.key_added,
+                  use_weights=args.use_weights,
+                  random_state=args.random_seed)
+
+    write_output_object(adata, args.output_object_file, args.output_format)
+
+    logging.info('Done')
+    return 0
+
+
+if __name__ == '__main__':
+    argparser = ScanpyArgParser('Run Louvain clustering on data with neighborhood graph computed')
+    argparser.add_input_object()
+    argparser.add_output_object()
+    argparser.add_argument('--flavor',
+                           choices=['vtraag', 'igraph'],
+                           default='vtraag',
+                           help='Choose between two packages for computing the clustering.'
+                                '"vtraag" is much more powerful, and the default.')
+    argparser.add_argument('--resolution',
+                           type=float,
+                           default=1.0,
+                           help='For the default flavor "vtraag", you can provide a resolution '
+                                '(higher resolution means finding more and smaller clusters). '
+                                'Default: 1.0')
+    argparser.add_argument('--restrict-to',
+                           type=comma_separated_list('restrict-to', str),
+                           default=[],
+                           help='Restrict the clustering to the categories within the key for '
+                                'sample annotation, tuple needs to contain (obs key, list of '
+                                'categories).')
+    argparser.add_argument('--key-added',
+                           default='louvain',
+                           help='Key under which to add the cluster labels. Default: louvain')
+    argparser.add_argument('--use-weights',
+                           action='store_true',
+                           default=False,
+                           help='Use weights from knn graph.')
+    argparser.add_argument('-s', '--random-seed',
+                           type=int,
+                           default=0,
+                           help='The seed used to initialise optimisation. Default: 0')
+    args = argparser.get_args()
+
+    main(args)

--- a/bin/scanpy-find-cluster.py
+++ b/bin/scanpy-find-cluster.py
@@ -50,7 +50,7 @@ if __name__ == '__main__':
                                 'Default: 1.0')
     argparser.add_argument('--restrict-to',
                            type=comma_separated_list('restrict-to', str),
-                           default=[],
+                           default=None,
                            help='Restrict the clustering to the categories within the key for '
                                 'sample annotation, tuple needs to contain (obs key, list of '
                                 'categories).')

--- a/scanpy-scripts-post-install-tests.bats
+++ b/scanpy-scripts-post-install-tests.bats
@@ -167,6 +167,7 @@
 
     [ "$status" -eq 0 ]
     [ -f  "$graph_object" ]
+}
 
 # Run find cluster
 

--- a/scanpy-scripts-post-install-tests.bats
+++ b/scanpy-scripts-post-install-tests.bats
@@ -167,6 +167,26 @@
 
     [ "$status" -eq 0 ]
     [ -f  "$graph_object" ]
+
+# Run find cluster
+
+@test "Run find cluster" {
+    if [ "$use_existing_outputs" = 'true' ] && [ -f "$cluster_object" ]; then
+        skip "$cluster_object exists and use_existing_outputs is set to 'true'"
+    fi
+
+    run rm -f $cluster_object $cluster_text_file && \
+	bin/scanpy-find-cluster.py -i $graph_object \
+				   -o $cluster_object \
+				   --output-text-file $cluster_text_file \
+				   --flavor $FC_flavor \
+				   --resolution $FC_resolution \
+				   --key-added $FC_key_added \
+				   -s $FC_random_seed \
+				   $FC_use_weight
+
+    [ "$status" -eq 0 ]
+    [ -f  "$cluster_object" ] && [ -f "$cluster_text_file" ]
 }
 
 # # Run UMAP

--- a/scanpy-scripts-post-install-tests.sh
+++ b/scanpy-scripts-post-install-tests.sh
@@ -75,12 +75,12 @@ export pca_loadings_file="$output_dir/pca_loadings.csv"
 export pca_stdev_file="$output_dir/pca_stdev.txt"
 export pca_var_ratio_file="$output_dir/pca_var_ratio.txt"
 export graph_object="$output_dir/graph.h5ad"
+export cluster_object="$output_dir/cluster.h5ad"
+export cluster_text_file="$output_dir/clusters.txt"
 export umap_object="$output_dir/umap.h5ad"
 export umap_image_file="$output_dir/umap.png"
 export tsne_object="$output_dir/tsne.h5ad"
 export tsne_image_file="$output_dir/tsne.png"
-#export cluster_seurat_object="$output_dir/cluster_seurat.rds"
-#export cluster_text_file="$output_dir/clusters.txt"
 #export tsne_seurat_object="$output_dir/tsne_seurat.rds"
 #export tsne_embeddings_file="$output_dir/tsne_embeddings.csv"
 #export marker_text_file="$output_dir/markers.csv"
@@ -129,6 +129,13 @@ export CG_npcs=50
 export CG_knn='--knn'
 export CG_random_seed=0
 export CG_method=umap
+
+# Run find cluster
+export FC_flavor=vtraag
+export FC_resolution='1.0'
+export FC_key_added=louvain
+export FC_use_weight='--use-weights'
+export FC_random_seed=0
 
 # Run UMAP
 export UMAP_min_dist='0.5'


### PR DESCRIPTION
This PR adds bin/scanpy-find-cluster.py which calls sc.tl.louvain() to cluster cells, save the clusters in the output object and optionally as a two column text table. It covers the following section of scanpy clustering tutorial:

> As Seurat and many others, we recommend the Louvain graph-clustering method (community detection based on optimizing modularity). It has been proposed for single-cell data by Levine et al. (2015). Note that Louvain clustering directly clusters the neighborhood graph of cells, which we already computed in the previous section.
> 
> `sc.tl.louvain(adata)`
> running Louvain clustering
>     using the "louvain" package of Traag (2017)
>     finished (0:00:00.20) --> found 8 clusters and added
>     'louvain', the cluster labels (adata.obs, categorical)