### PR TITLE
Feature/find marker

### DIFF
--- a/bin/scanpy-find-markers.py
+++ b/bin/scanpy-find-markers.py
@@ -1,0 +1,119 @@
+#!/usr/bin/env python
+
+from __future__ import print_function
+import logging
+import numpy as np
+import pandas as pd
+import matplotlib
+matplotlib.use('Agg')
+import scanpy.api as sc
+from scanpy_wrapper_utils import ScanpyArgParser, comma_separated_list
+from scanpy_wrapper_utils import read_input_object, write_output_object, save_output_plot
+
+
+def main(args):
+    logging.debug(args)
+
+    adata = read_input_object(args.input_object_file, args.input_format)
+
+    if len(args.groups) == 1:
+        args.groups = args.groups[0]
+
+    sc.tl.rank_genes_groups(adata,
+                            groupby=args.groupby,
+                            use_raw=args.use_raw,
+                            groups=args.groups,
+                            reference=args.reference,
+                            n_genes=args.n_genes,
+                            method=args.method,
+                            rankby_abs=args.rankby_abs)
+
+    write_output_object(adata, args.output_object_file, args.output_format)
+
+    if args.output_text_file:
+        export_marker_table(adata, args.output_text_file)
+
+    if args.output_plot:
+        sc.set_figure_params(format=args.output_plot_format)
+        sc.settings.verbosity = 0
+        sc.pl.rank_genes_groups_stacked_violin(adata, n_genes=args.show_n_genes, key=args.key,
+                                               show=False, save=True)
+        save_output_plot('stacked_violin', args.output_plot)
+
+    logging.info('Done')
+    return 0
+
+
+def recarray_to_array(x):
+    dtyp = x.dtype[0]
+    return x.view(dtyp)
+
+
+def export_marker_table(adata, filename):
+    result = adata.uns['rank_genes_groups']
+    n_genes = len(result['names'])
+    n_group = len(result['names'][0])
+    groups = np.tile(np.arange(n_group), n_genes)
+    names = recarray_to_array(result['names'])
+    scores = recarray_to_array(result['scores'])
+    logfc = recarray_to_array(result['logfoldchanges'])
+    pvals = recarray_to_array(result['pvals'])
+    pvals_adj = recarray_to_array(result['pvals_adj'])
+    marker_tbl = pd.DataFrame({'names':names, 'groups':groups, 'scores':scores, 'logfc':logfc,
+                               'pvals':pvals, 'pvals_adj':pvals_adj})
+    marker_tbl.sort_values(by=['groups', 'pvals_adj']).to_csv(filename, index=None)
+
+
+if __name__ == '__main__':
+    argparser = ScanpyArgParser('Keep variable genes')
+    argparser.add_input_object()
+    argparser.add_output_object()
+    argparser.add_argument('--output-text-file',
+                           default=None,
+                           help='File name in which to store a text table of marker genes.')
+    argparser.add_argument('-g', '--groupby',
+                           default='louvain',
+                           help='The key of the observations grouping to consider. '
+                                'Default: louvain')
+    argparser.add_argument('--no-raw',
+                           dest='use_raw',
+                           action='store_false',
+                           default=True,
+                           help='Use raw attribute if present.')
+    argparser.add_argument('--groups',
+                           type=comma_separated_list('groups', str),
+                           default='all',
+                           help='Subset of groups, e.g. "g1,g2,g3", to which comparison shall be '
+                                'restricted. If not passed, a raning will be generated for all '
+                                'groups.')
+    argparser.add_argument('--reference',
+                           default='rest',
+                           help='If "rest", compare each group to the union of the rest of the '
+                                'group. If a group identifier, compare with respect to this group.')
+    argparser.add_argument('-n', '--n-genes',
+                           type=int,
+                           default=100,
+                           help='The number of genes that appear in the returned tables.')
+    argparser.add_argument('-m', '--method',
+                           choices=['logreg', 't-test', 'wilcoxon', 't-test_overestim_var'],
+                           default='t-test_overestim_var',
+                           help='If "t-test", uses t-test, if "wilcoxon", uses '
+                                'Wilcoxon-Rank-Sum. If "t-test_overestim_var", overestimates '
+                                'variance of each group. If "logreg" uses logistic regression. '
+                                'Default: "t-test_overestim_var".')
+    argparser.add_argument('--rankby_abs',
+                           action='store_true',
+                           default=False,
+                           help='Rank genes by the absolute value of the score, not by the '
+                                'score. The returned scores are never the absolute values.')
+    argparser.add_output_plot()
+    argparser.add_argument('--show-n-genes',
+                           type=int,
+                           default=10,
+                           help='Number of genes to show per group in plot. Default: 10')
+    argparser.add_argument('--key',
+                           default=None,
+                           help='Key used to store the ranking results in adata.uns.')
+    args = argparser.get_args()
+
+    main(args)

--- a/bin/scanpy-find-markers.py
+++ b/bin/scanpy-find-markers.py
@@ -44,9 +44,9 @@ def main(args):
     return 0
 
 
-def recarray_to_array(x):
-    dtyp = x.dtype[0]
-    return x.view(dtyp)
+def recarray_to_array(rec):
+    dtyp = rec.dtype[0]
+    return rec.view(dtyp)
 
 
 def export_marker_table(adata, filename):

--- a/scanpy-scripts-post-install-tests.bats
+++ b/scanpy-scripts-post-install-tests.bats
@@ -197,7 +197,7 @@
         skip "$umap_object exists and use_existing_outputs is set to 'true'"
     fi
 
-    run rm -f $umap_object $umap_image_file && \
+    run rm -f $umap_object $umap_image_file $umap_embeddings_file && \
 	bin/scanpy-run-umap.py -i $cluster_object -o $umap_object \
 			       --output-embeddings-file $umap_embeddings_file \
 			       -s $UMAP_random_seed \
@@ -215,7 +215,7 @@
     [ "$status" -eq 0 ]
     [ -f  "$umap_object" ] && [ -f "$umap_image_file" ] && [ -f "$umap_embeddings_file" ]
 }
-# 
+
 # Run TSNE
 
 @test "Run TSNE analysis" {
@@ -223,7 +223,7 @@
         skip "$tsne_object exists and use_existing_outputs is set to 'true'"
     fi
 
-    run rm -f $tsne_object $tsne_image_file && \
+    run rm -f $tsne_object $tsne_image_file $tsne_embeddings_file && \
 	bin/scanpy-run-tsne.py -i $cluster_object -o $tsne_object \
 			       --output-embeddings-file $tsne_embeddings_file \
 			       -s $TSNE_random_seed \
@@ -237,6 +237,30 @@
 
     [ "$status" -eq 0 ]
     [ -f  "$tsne_object" ] && [ -f "$tsne_image_file" ] && [ -f "$tsne_embeddings_file" ]
+}
+
+# Run find markers
+
+@test "Run find markers" {
+    if [ "$use_existing_outputs" = 'true' ] && [ -f "$marker_object" ]; then
+        skip "$marker_object exists and use_existing_outputs is set to 'true'"
+    fi
+
+    run rm -f $marker_object $marker_image_file $marker_text_file && \
+	bin/scanpy-find-markers.py -i $cluster_object -o $marker_object \
+				   --output-text-file $marker_text_file \
+				   --groupby $FM_groupby \
+				   --groups $FM_groups \
+				   --reference $FM_reference \
+				   --n-genes $FM_n_genes \
+				   --method $FM_method \
+				   -P $marker_image_file \
+				   --show-n-genes $FM_show_n_genes \
+				   --debug \
+				   --key $FM_key
+
+    [ "$status" -eq 0 ]
+    [ -f  "$marker_object" ] && [ -f "$marker_image_file" ] && [ -f "$marker_text_file" ]
 }
 
 # Local Variables:

--- a/scanpy-scripts-post-install-tests.sh
+++ b/scanpy-scripts-post-install-tests.sh
@@ -83,7 +83,9 @@ export umap_image_file="$output_dir/umap.png"
 export tsne_object="$output_dir/tsne.h5ad"
 export tsne_image_file="$output_dir/tsne.png"
 export tsne_embeddings_file="$output_dir/tsne_embeddings.csv"
-#export marker_text_file="$output_dir/markers.csv"
+export marker_object="$output_dir/marker.h5ad"
+export marker_image_file="$output_dir/markers.png"
+export marker_text_file="$output_dir/markers.csv"
 
 ## Test parameters- would form config file in real workflow. DO NOT use these
 ## as default values without being sure what they mean.
@@ -158,6 +160,15 @@ export TSNE_random_seed=0
 export TSNE_color=louvain
 export TSNE_projection=2d
 export TSNE_frameon='--frameoff'
+
+# Run find marker
+export FM_groupby=louvain
+export FM_groups=all
+export FM_reference=rest
+export FM_n_genes=50
+export FM_method='t-test_overestim_var'
+export FM_show_n_genes=5
+export FM_key='rank_genes_groups'
 
 ################################################################################
 # Test individual scripts


### PR DESCRIPTION
This PR adds bin/scanpy-find-markers.py, which takes an AnnData object with cluster information, rank DE genes in each cluster, writes the ranking to an output object and writes top ranking genes with stats to a text table. It covers the following section of scanpy clustering tutorial:

> Let us compute a ranking for the highly differential genes in each cluster. Here, we simply rank genes with a t test, which agrees quite well with Seurat.
> 
> For this, by default, the .raw attribute of AnnData is used in case it has been initialized before.
> 
> ```
> adata = sc.read(results_file)
> sc.tl.rank_genes_groups(adata, 'louvain')
> sc.pl.rank_genes_groups(adata, n_genes=20, sharey=False, save='.pdf')
> adata.write(results_file)
> ```