### PR TITLE
Replace non-ascii left and right single quote with double quotes

### DIFF
--- a/scanpy-neighbours.py
+++ b/scanpy-neighbours.py
@@ -45,7 +45,7 @@ if __name__ == '__main__':
                            default=None,
                            help='Use the indicated representation. '
                                 'If None, the representation is chosen automatically: '
-                                'for .n_vars < 50, .X is used, otherwise ‘X_pca’ is used.')
+                                'for .n_vars < 50, .X is used, otherwise "X_pca" is used.')
     argparser.add_argument('--knn',
                            dest='knn',
                            action='store_true',


### PR DESCRIPTION
This PR is a bugfix to replace non-ascii left and right single quote with double quotes in usage message of scanpy-neighbours.py. These non-ascii seem to cause trouble in bioconda CI test building under a minimum environment.