### PR TITLE
Add mtx export to other matrix-altering scripts

### DIFF
--- a/scanpy-filter-cells.py
+++ b/scanpy-filter-cells.py
@@ -3,7 +3,7 @@
 from __future__ import print_function
 import logging
 import scanpy.api as sc
-from scanpy_wrapper_utils import ScanpyArgParser, read_input_object, write_output_object, output_mtx
+from scanpy_wrapper_utils import ScanpyArgParser, read_input_object, write_output_object, export_mtx
 
 
 def main(args):

--- a/scanpy-filter-cells.py
+++ b/scanpy-filter-cells.py
@@ -3,7 +3,7 @@
 from __future__ import print_function
 import logging
 import scanpy.api as sc
-from scanpy_wrapper_utils import ScanpyArgParser, read_input_object, write_output_object
+from scanpy_wrapper_utils import ScanpyArgParser, read_input_object, write_output_object, output_mtx
 
 
 def main(args):
@@ -33,6 +33,9 @@ def main(args):
             adata = adata[(adata.obs[name] < high) & (adata.obs[name] > low), :]
 
     write_output_object(adata, args.output_object_file, args.output_format)
+    
+    if args.export_mtx:
+        export_mtx(adata, args.export_mtx)
 
     print(adata)
     logging.info('Done')
@@ -45,6 +48,11 @@ if __name__ == "__main__":
     argparser.add_output_object()
     argparser.add_subset_parameters()
     argparser.add_subset_list()
+    argparser.add_argument('-x', '--export-mtx',
+                           type=str,
+                           default=None,
+                           help='Export normalised data in mtx format with the supplied '
+                                'string being the prefix of the output files.')
     args = argparser.get_args()
 
     main(args)

--- a/scanpy-filter-cells.py
+++ b/scanpy-filter-cells.py
@@ -34,8 +34,8 @@ def main(args):
 
     write_output_object(adata, args.output_object_file, args.output_format)
     
-    if args.export_mtx:
-        export_mtx(adata, args.export_mtx)
+    if args.export_mtx is not None:
+        export_mtx(adata, fname_prefix=args.export_mtx)
 
     print(adata)
     logging.info('Done')

--- a/scanpy-filter-genes.py
+++ b/scanpy-filter-genes.py
@@ -3,7 +3,7 @@
 from __future__ import print_function
 import logging
 import scanpy.api as sc
-from scanpy_wrapper_utils import ScanpyArgParser, read_input_object, write_output_object, output_mtx
+from scanpy_wrapper_utils import ScanpyArgParser, read_input_object, write_output_object, export_mtx
 
 
 def main(args):

--- a/scanpy-filter-genes.py
+++ b/scanpy-filter-genes.py
@@ -36,8 +36,8 @@ def main(args):
         else:
             adata = adata[(adata.var[name] < high) & (adata.var[name] > low), :]
 
-    if args.export_mtx:
-        export_mtx(adata, args.export_mtx)
+    if args.export_mtx is not None:
+        export_mtx(adata, fname_prefix=args.export_mtx)
     
     write_output_object(adata, args.output_object_file, args.output_format)
 

--- a/scanpy-filter-genes.py
+++ b/scanpy-filter-genes.py
@@ -3,7 +3,7 @@
 from __future__ import print_function
 import logging
 import scanpy.api as sc
-from scanpy_wrapper_utils import ScanpyArgParser, read_input_object, write_output_object
+from scanpy_wrapper_utils import ScanpyArgParser, read_input_object, write_output_object, output_mtx
 
 
 def main(args):
@@ -36,6 +36,9 @@ def main(args):
         else:
             adata = adata[(adata.var[name] < high) & (adata.var[name] > low), :]
 
+    if args.export_mtx:
+        export_mtx(adata, args.export_mtx)
+    
     write_output_object(adata, args.output_object_file, args.output_format)
 
     print(adata)
@@ -49,6 +52,11 @@ if __name__ == '__main__':
     argparser.add_output_object()
     argparser.add_subset_parameters()
     argparser.add_subset_list()
+    argparser.add_argument('-x', '--export-mtx',
+                           type=str,
+                           default=None,
+                           help='Export normalised data in mtx format with the supplied '
+                                'string being the prefix of the output files.')
     args = argparser.get_args()
 
     main(args)

--- a/scanpy-find-variable-genes.py
+++ b/scanpy-find-variable-genes.py
@@ -9,7 +9,7 @@ from scanpy_wrapper_utils import ScanpyArgParser
 from scanpy_wrapper_utils import read_input_object
 from scanpy_wrapper_utils import write_output_object
 from scanpy_wrapper_utils import save_output_plot
-from scanpy_wrapper_utils import output_mtx
+from scanpy_wrapper_utils import export_mtx
 
 
 def main(args):

--- a/scanpy-find-variable-genes.py
+++ b/scanpy-find-variable-genes.py
@@ -9,6 +9,7 @@ from scanpy_wrapper_utils import ScanpyArgParser
 from scanpy_wrapper_utils import read_input_object
 from scanpy_wrapper_utils import write_output_object
 from scanpy_wrapper_utils import save_output_plot
+from scanpy_wrapper_utils import output_mtx
 
 
 def main(args):
@@ -49,6 +50,9 @@ def main(args):
                                   n_top_genes=args.n_top_genes,
                                   log=(args.flavor == 'seurat'))
 
+    if args.export_mtx:
+        export_mtx(adata, args.export_mtx)
+    
     write_output_object(adata, args.output_object_file, args.output_format)
 
     print(adata)
@@ -77,6 +81,11 @@ if __name__ == '__main__':
                            default=None,
                            help='Number of highly variable genes to keep, '
                                 'ignoring --subset-parameters when set. Default: None')
+    argparser.add_argument('-x', '--export-mtx',
+                           type=str,
+                           default=None,
+                           help='Export normalised data in mtx format with the supplied '
+                                'string being the prefix of the output files.')
     args = argparser.get_args()
 
     main(args)

--- a/scanpy-find-variable-genes.py
+++ b/scanpy-find-variable-genes.py
@@ -50,8 +50,8 @@ def main(args):
                                   n_top_genes=args.n_top_genes,
                                   log=(args.flavor == 'seurat'))
 
-    if args.export_mtx:
-        export_mtx(adata, args.export_mtx)
+    if args.export_mtx is not None:
+        export_mtx(adata, fname_prefix=args.export_mtx)
     
     write_output_object(adata, args.output_object_file, args.output_format)
 

--- a/scanpy-scale-data.py
+++ b/scanpy-scale-data.py
@@ -4,7 +4,7 @@ from __future__ import print_function
 import logging
 import scanpy.api as sc
 from scanpy_wrapper_utils import ScanpyArgParser, comma_separated_list
-from scanpy_wrapper_utils import read_input_object, write_output_object, output_mtx
+from scanpy_wrapper_utils import read_input_object, write_output_object, export_mtx
 
 
 def main(args):

--- a/scanpy-scale-data.py
+++ b/scanpy-scale-data.py
@@ -20,8 +20,8 @@ def main(args):
 
     sc.pp.scale(adata, zero_center=args.zero_center, max_value=args.scale_max)
     
-    if args.export_mtx:
-        export_mtx(adata, args.export_mtx)
+    if args.export_mtx is not None:
+        export_mtx(adata, fname_prefix=args.export_mtx)
 
     write_output_object(adata, args.output_object_file, args.output_format)
 

--- a/scanpy-scale-data.py
+++ b/scanpy-scale-data.py
@@ -4,7 +4,7 @@ from __future__ import print_function
 import logging
 import scanpy.api as sc
 from scanpy_wrapper_utils import ScanpyArgParser, comma_separated_list
-from scanpy_wrapper_utils import read_input_object, write_output_object
+from scanpy_wrapper_utils import read_input_object, write_output_object, output_mtx
 
 
 def main(args):
@@ -19,6 +19,9 @@ def main(args):
         sc.pp.regress_out(adata, args.var_to_regress)
 
     sc.pp.scale(adata, zero_center=args.zero_center, max_value=args.scale_max)
+    
+    if args.export_mtx:
+        export_mtx(adata, args.export_mtx)
 
     write_output_object(adata, args.output_object_file, args.output_format)
 
@@ -56,6 +59,11 @@ if __name__ == '__main__':
                            default=None,
                            help='Truncate to this value after scaling. '
                                 'Do not truncate if None. Default: None')
+    argparser.add_argument('-e', '--export-mtx',
+                           type=str,
+                           default=None,
+                           help='Export normalised data in mtx format with the supplied '
+                                'string being the prefix of the output files.')
     args = argparser.get_args()
 
     main(args)


### PR DESCRIPTION
This PR adds the mtx output @nh3 added to the normalisation step to other matrix-altering Scanpy steps. 

@nh3 - I need to use a '-e' short argument for scale-data, since -x was in use. 