### PR TITLE
Allow specifying cell/gene prefix for all filtering attributes

### DIFF
--- a/scanpy-scripts-tests.bats
+++ b/scanpy-scripts-tests.bats
@@ -11,7 +11,7 @@ setup() {
     raw_matrix="${data_dir}/matrix.mtx"
     read_opt="-x $data_dir --show-obj stdout"
     read_obj="${output_dir}/read.h5ad"
-    filter_opt="-p n_genes 200 2500 -p cell:n_counts 0 50000 -p n_cells 3 inf -p pct_counts_mito 0 0.2 --show-obj stdout"
+    filter_opt="-p n_genes 200 2500 -p c:n_counts 0 50000 -p n_cells 3 inf -p pct_counts_mito 0 0.2 --show-obj stdout"
     filter_obj="${output_dir}/filter.h5ad"
     norm_mtx="${output_dir}/norm"
     norm_opt="-r yes -t 10000 -X ${norm_mtx} --show-obj stdout"

--- a/scanpy_scripts/lib/_filter.py
+++ b/scanpy_scripts/lib/_filter.py
@@ -63,7 +63,7 @@ def filter_anndata(
 
     if qc_vars or pct_top:
         if not pct_top:
-            pct_top = [1]
+            pct_top = [50]
         sc.pp.calculate_qc_metrics(
             adata, qc_vars=qc_vars, percent_top=pct_top, inplace=True)
 

--- a/setup.py
+++ b/setup.py
@@ -40,6 +40,7 @@ setup(
         'scipy>=1.2.0,<1.3.0',
         'matplotlib',
         'pandas',
+        'h5py<2.10',
         'scanpy>=1.4.2,<1.4.4',
         'louvain',
         'leidenalg',

--- a/setup.py
+++ b/setup.py
@@ -43,7 +43,7 @@ setup(
         'scanpy>=1.4.2,<1.4.4',
         'louvain',
         'leidenalg',
-        'loompy',
+        'loompy>=2.0.0,<3.0.0',
         'MulticoreTSNE',
         'Click'
     ],


### PR DESCRIPTION
This PR allows specifying cell/gene prefix for filtering attributes in the format of "c:" or "g:". If not specified, it will look for matching columns in cell/gene table and drop ambiguous attributes. This addresses https://github.com/ebi-gene-expression-group/container-galaxy-sc-tertiary/issues/84

Additional bug fixes:
Fix bug in --subset handling
Fix bug when adding adata.var['mito']

Test updated.