### PR TITLE
Make log tranform optional on normalisation

### DIFF
--- a/scanpy_scripts/cmd_options.py
+++ b/scanpy_scripts/cmd_options.py
@@ -333,11 +333,11 @@ NORM_CMD_OPTIONS = [
         help='Save raw data existing raw data.',
     ),
     click.option(
-        '--log-transform', '-l',
-        type=click.Choice(['yes', 'no']),
-        default='yes',
+        '--no-log-transform', '-l',
+        is_flag=True,
+        default=False,
         show_default=True,
-        help='Apply (natural) log transform following normalisation?',
+        help='When set, do not apply (natural) log transform following normalisation.',
     ),
     click.option(
         '--normalize-to', '-t', 'target_sum',

--- a/scanpy_scripts/cmd_options.py
+++ b/scanpy_scripts/cmd_options.py
@@ -333,6 +333,13 @@ NORM_CMD_OPTIONS = [
         help='Save raw data existing raw data.',
     ),
     click.option(
+        '--log-transform', '-l',
+        type=click.Choice(['yes', 'no']),
+        default='yes',
+        show_default=True,
+        help='Apply (natural) log transform following normalisation?',
+    ),
+    click.option(
         '--normalize-to', '-t', 'target_sum',
         type=float,
         default=10_000,

--- a/scanpy_scripts/cmd_options.py
+++ b/scanpy_scripts/cmd_options.py
@@ -333,9 +333,9 @@ NORM_CMD_OPTIONS = [
         help='Save raw data existing raw data.',
     ),
     click.option(
-        '--no-log-transform', '-l',
+        '--no-log-transform', 'log_transform',
         is_flag=True,
-        default=False,
+        default=True,
         show_default=True,
         help='When set, do not apply (natural) log transform following normalisation.',
     ),
@@ -644,7 +644,8 @@ TSNE_CMD_OPTIONS = [
         flag_value=False,
         default=True,
         show_default=True,
-        help='Use the MulticoreTSNE package by D. Ulyanov if it is installed.',
+        help='When NOT set, use the MulticoreTSNE package by D. Ulyanov if '
+        'installed.',
     ),
 ]
 

--- a/scanpy_scripts/lib/_norm.py
+++ b/scanpy_scripts/lib/_norm.py
@@ -5,7 +5,7 @@ scanpy norm
 import scanpy as sc
 
 
-def normalize(adata, save_raw='yes', **kwargs):
+def normalize(adata, save_raw='yes', log_transform='yes', **kwargs):
     """
     Wrapper function for sc.pp.normalize_per_cell() and sc.pp.log1p(), mainly
     for supporting different ways of saving raw data.
@@ -13,7 +13,8 @@ def normalize(adata, save_raw='yes', **kwargs):
     if save_raw == 'counts':
         adata.raw = adata
     sc.pp.normalize_total(adata, **kwargs)
-    sc.pp.log1p(adata)
+    if log_transform == 'yes':
+        sc.pp.log1p(adata)
     if save_raw == 'yes':
         adata.raw = adata
 

--- a/scanpy_scripts/lib/_norm.py
+++ b/scanpy_scripts/lib/_norm.py
@@ -5,7 +5,7 @@ scanpy norm
 import scanpy as sc
 
 
-def normalize(adata, save_raw='yes', no_log_transform=False, **kwargs):
+def normalize(adata, save_raw='yes', log_transform=True, **kwargs):
     """
     Wrapper function for sc.pp.normalize_per_cell() and sc.pp.log1p(), mainly
     for supporting different ways of saving raw data.
@@ -13,7 +13,7 @@ def normalize(adata, save_raw='yes', no_log_transform=False, **kwargs):
     if save_raw == 'counts':
         adata.raw = adata
     sc.pp.normalize_total(adata, **kwargs)
-    if not no_log_transform:
+    if log_transform:
         sc.pp.log1p(adata)
     if save_raw == 'yes':
         adata.raw = adata

--- a/scanpy_scripts/lib/_norm.py
+++ b/scanpy_scripts/lib/_norm.py
@@ -5,7 +5,7 @@ scanpy norm
 import scanpy as sc
 
 
-def normalize(adata, save_raw='yes', log_transform='yes', **kwargs):
+def normalize(adata, save_raw='yes', no_log_transform=False, **kwargs):
     """
     Wrapper function for sc.pp.normalize_per_cell() and sc.pp.log1p(), mainly
     for supporting different ways of saving raw data.
@@ -13,7 +13,7 @@ def normalize(adata, save_raw='yes', log_transform='yes', **kwargs):
     if save_raw == 'counts':
         adata.raw = adata
     sc.pp.normalize_total(adata, **kwargs)
-    if log_transform == 'yes':
+    if not no_log_transform:
         sc.pp.log1p(adata)
     if save_raw == 'yes':
         adata.raw = adata


### PR DESCRIPTION
This PR (assuming I've understood things correctly) makes the log transform on normalisation optional (though still the default, as per Scanpy author recommendations).