### PR TITLE
Feature/merge rgg

### DIFF
--- a/scanpy-scripts-tests.bats
+++ b/scanpy-scripts-tests.bats
@@ -63,10 +63,11 @@ setup() {
     plt_dotplot_pdf="${output_dir}/dot_${test_clustering}_LDHB_CD3D_CD3E.pdf"
     plt_matrixplot_pdf="${output_dir}/matrix_${test_clustering}_LDHB_CD3D_CD3E.pdf"
     plt_heatmap_pdf="${output_dir}/heatmap_${test_clustering}_LDHB_CD3D_CD3E.pdf"
-    plt_rank_genes_groups_opt="--groups 3,5"
-    plt_rank_genes_groups_stacked_violin_pdf="${output_dir}/rggsviolin_${test_clustering}_LDHB_CD3D_CD3E.pdf"
-    plt_rank_genes_groups_matrix_pdf="${output_dir}/rggmatrix_${test_clustering}_LDHB_CD3D_CD3E.pdf"
-    plt_rank_genes_groups_heatmap_pdf="${output_dir}/rggheatmap_${test_clustering}_LDHB_CD3D_CD3E.pdf"
+    plt_rank_genes_groups_opt="--rgg --groups 3,5"
+    plt_rank_genes_groups_stacked_violin_pdf="${output_dir}/rggsviolin_${test_clustering}.pdf"
+    plt_rank_genes_groups_matrix_pdf="${output_dir}/rggmatrix_${test_clustering}.pdf"
+    plt_rank_genes_groups_dot_pdf="${output_dir}/rggdot_${test_clustering}.pdf"
+    plt_rank_genes_groups_heatmap_pdf="${output_dir}/rggheatmap_${test_clustering}.pdf"
 
     if [ ! -d "$data_dir" ]; then
         mkdir -p $data_dir
@@ -355,7 +356,7 @@ setup() {
         skip "$plt_rank_genes_groups_stacked_violin_pdf exists and resume is set to 'true'"
     fi
 
-    run rm -f $plt_rank_genes_groups_stacked_violin_pdf && eval "$scanpy plot rggsviol $plt_rank_genes_groups_opt $diffexp_obj $plt_rank_genes_groups_stacked_violin_pdf"
+    run rm -f $plt_rank_genes_groups_stacked_violin_pdf && eval "$scanpy plot sviol $plt_rank_genes_groups_opt $diffexp_obj $plt_rank_genes_groups_stacked_violin_pdf"
 
     [ "$status" -eq 0 ]
     [ -f  "$plt_rank_genes_groups_stacked_violin_pdf" ]
@@ -373,6 +374,20 @@ setup() {
     [ "$status" -eq 0 ]
     [ -f  "$plt_dotplot_pdf" ]
 }
+
+# Plot ranking of genes using a matrix plot for markers
+
+@test "Run Plot ranking of genes using a dot plot" {
+    if [ "$resume" = 'true' ] && [ -f "$plt_rank_genes_groups_dot_pdf" ]; then
+        skip "$plt_rank_genes_groups_dot_pdf exists and resume is set to 'true'"
+    fi
+
+    run rm -f $plt_rank_genes_groups_dot_pdf && eval "$scanpy plot dot $plt_rank_genes_groups_opt $diffexp_obj $plt_rank_genes_groups_dot_pdf"
+
+    [ "$status" -eq 0 ]
+    [ -f  "$plt_rank_genes_groups_dot_pdf" ]
+}
+
 
 # Plot a matrix plot for markers
 
@@ -394,7 +409,7 @@ setup() {
         skip "$plt_rank_genes_groups_matrix_pdf exists and resume is set to 'true'"
     fi
 
-    run rm -f $plt_rank_genes_groups_matrix_pdf && eval "$scanpy plot rggmatrix $plt_rank_genes_groups_opt $diffexp_obj $plt_rank_genes_groups_matrix_pdf"
+    run rm -f $plt_rank_genes_groups_matrix_pdf && eval "$scanpy plot matrix $plt_rank_genes_groups_opt $diffexp_obj $plt_rank_genes_groups_matrix_pdf"
 
     [ "$status" -eq 0 ]
     [ -f  "$plt_rank_genes_groups_matrix_pdf" ]
@@ -420,7 +435,7 @@ setup() {
         skip "$plt_rank_genes_groups_heatmap_pdf exists and resume is set to 'true'"
     fi
 
-    run rm -f $plt_rank_genes_groups_heatmap_pdf && eval "$scanpy plot rggheat $plt_rank_genes_groups_opt $diffexp_obj $plt_rank_genes_groups_heatmap_pdf"
+    run rm -f $plt_rank_genes_groups_heatmap_pdf && eval "$scanpy plot heat $plt_rank_genes_groups_opt $diffexp_obj $plt_rank_genes_groups_heatmap_pdf"
 
     [ "$status" -eq 0 ]
     [ -f  "$plt_rank_genes_groups_matrix_pdf" ]

--- a/scanpy_scripts/cli.py
+++ b/scanpy_scripts/cli.py
@@ -27,12 +27,9 @@ from .cmds import (
     PLOT_EMBED_CMD,
     PLOT_PAGA_CMD,
     PLOT_STACKED_VIOLIN_CMD,
-    PLOT_RANK_GENE_GROUPS_STACKED_VIOLIN_CMD,
     PLOT_DOT_CMD,
     PLOT_MATRIX_CMD,
-    PLOT_RANK_GENE_GROUPS_MATRIX_CMD,
     PLOT_HEATMAP_CMD,
-    PLOT_RANK_GENE_GROUPS_HEATMAP_CMD,
 )
 
 
@@ -112,9 +109,6 @@ def plot():
 plot.add_command(PLOT_EMBED_CMD)
 plot.add_command(PLOT_PAGA_CMD)
 plot.add_command(PLOT_STACKED_VIOLIN_CMD)
-plot.add_command(PLOT_RANK_GENE_GROUPS_STACKED_VIOLIN_CMD)
 plot.add_command(PLOT_DOT_CMD)
 plot.add_command(PLOT_MATRIX_CMD)
-plot.add_command(PLOT_RANK_GENE_GROUPS_MATRIX_CMD)
 plot.add_command(PLOT_HEATMAP_CMD)
-plot.add_command(PLOT_RANK_GENE_GROUPS_HEATMAP_CMD)

--- a/scanpy_scripts/cmd_options.py
+++ b/scanpy_scripts/cmd_options.py
@@ -239,6 +239,14 @@ COMMON_OPTIONS = {
 
     'diffexp_plot': [
         click.option(
+            '--rgg',
+            is_flag=True,
+            default=False,
+            show_default=True,
+            help='When set, use the rank_genes_groups_ form of the function, '
+            'where gene lists are automatically selected.',
+        ),
+        click.option(
              '--groupby',
             type=CommaSeparatedText(simplify=True),
             default=None,
@@ -302,7 +310,7 @@ COMMON_OPTIONS = {
 
     ],
 
-    'stacked_violin': [
+    'sviol': [
         click.option(
             '--no-stripplot', 'stripplot',
             is_flag=True,
@@ -313,9 +321,9 @@ COMMON_OPTIONS = {
         click.option(
             '--no-jitter', 'jitter',
             is_flag=True,
-            default=False,
+            default=True,
             show_default=True,
-            help='Add jitter to the stripplot (only when stripplot is True)'
+            help='Suppress jitter in the stripplot (only when stripplot is True)'
         ),
         click.option(
             '--size',
@@ -355,7 +363,61 @@ COMMON_OPTIONS = {
         ),
     ],
 
-    'heatmap': [
+
+    'dot': [
+        click.option(
+            '--expression-cutoff',
+            type=click.FLOAT,
+            default=0,
+            show_default=True,
+            help='Expression cutoff that is used for binarizing the gene expression '
+            'and determining the fraction of cells expressing given genes. A gene is '
+            'expressed only if the expression value is greater than this threshold.'
+        ),
+        click.option(
+            '--mean-only-expressed',
+            is_flag=True,
+            default=False,
+            show_default=True,
+            help='If True, gene expression is averaged only over the cells '
+            'expressing the given genes.',
+        ),
+        click.option(
+            '--color-map',
+            type=CommaSeparatedText(simplify=True),
+            default='Reds',
+            show_default=True,
+            help='String denoting matplotlib color map.',
+        ),
+        click.option(
+            '--dot-max',
+            type=click.FLOAT,
+            default=None,
+            show_default=True,
+            help='If none, the maximum dot size is set to the maximum fraction '
+            'value found (e.g. 0.6). If given, the value should be a number between '
+            '0 and 1. All fractions larger than dot_max are clipped to this value.'
+        ),
+        click.option(
+            '--dot-min',
+            type=click.FLOAT,
+            default=None,
+            show_default=True,
+            help='If none, the minimum dot size is set to 0. If given, the value '
+            'should be a number between 0 and 1. All fractions smaller than dot_min '
+            'are clipped to this value.'
+        ),
+        click.option(
+            '--smallest-dot',
+            type=click.FLOAT,
+            default=0,
+            show_default=True,
+            help='If none, the smallest dot has size 0. All expression levels with '
+            'dot_min are potted with smallest_dot dot size.'
+        ),
+    ],
+
+    'heat': [
         click.option(
             '--show-gene-labels',
             is_flag=True,
@@ -395,955 +457,885 @@ COMMON_OPTIONS = {
     ]
 }
 
-READ_CMD_OPTIONS = [
-    click.option(
-        '--input-10x-h5', '-i',
-        type=click.Path(exists=True, dir_okay=False),
-        callback=mutually_exclusive_with('--input-10x-mtx'),
-        help='Input 10x data in Cell-Ranger hdf5 format.',
-    ),
-    click.option(
-        '--input-10x-mtx', '-x',
-        type=click.Path(exists=True, file_okay=False),
-        callback=mutually_exclusive_with('--input-10x-h5'),
-        help='Path of input folder containing 10x data in mtx format.',
-    ),
-    *COMMON_OPTIONS['output'],
-    click.option(
-        '--genome', '-g',
-        callback=required_by('--input-10x-h5'),
-        default='hg19',
-        show_default=True,
-        help='Name of the genome group in hdf5 file, required by '
-        '"--input-10x-h5".',
-    ),
-    click.option(
-        '--var-names', '-v',
-        type=click.Choice(['gene_symbols', 'gene_ids']),
-        callback=required_by('--input-10x-mtx'),
-        default='gene_symbols',
-        show_default=True,
-        help='Attribute to be used as the index of the variable table, '
-        'required by "--input-10x-mtx".',
-    ),
-    click.option(
-        '--extra-obs',
-        type=click.Path(exists=True, dir_okay=False),
-        default=None,
-        show_default=True,
-        help='Extra cell metadata table, must be tab-separated with a header '
-        'row and an index column, and with matched dimension.',
-    ),
-    click.option(
-        '--extra-var',
-        type=click.Path(exists=True, dir_okay=False),
-        default=None,
-        show_default=True,
-        help='Extra gene metadata table, must be tab-separated with a header '
-        'row and an index column, and with matched dimension.',
-    ),
-]
+CMD_OPTIONS = {
+    'read': [
+        click.option(
+            '--input-10x-h5', '-i',
+            type=click.Path(exists=True, dir_okay=False),
+            callback=mutually_exclusive_with('--input-10x-mtx'),
+            help='Input 10x data in Cell-Ranger hdf5 format.',
+        ),
+        click.option(
+            '--input-10x-mtx', '-x',
+            type=click.Path(exists=True, file_okay=False),
+            callback=mutually_exclusive_with('--input-10x-h5'),
+            help='Path of input folder containing 10x data in mtx format.',
+        ),
+        *COMMON_OPTIONS['output'],
+        click.option(
+            '--genome', '-g',
+            callback=required_by('--input-10x-h5'),
+            default='hg19',
+            show_default=True,
+            help='Name of the genome group in hdf5 file, required by '
+            '"--input-10x-h5".',
+        ),
+        click.option(
+            '--var-names', '-v',
+            type=click.Choice(['gene_symbols', 'gene_ids']),
+            callback=required_by('--input-10x-mtx'),
+            default='gene_symbols',
+            show_default=True,
+            help='Attribute to be used as the index of the variable table, '
+            'required by "--input-10x-mtx".',
+        ),
+        click.option(
+            '--extra-obs',
+            type=click.Path(exists=True, dir_okay=False),
+            default=None,
+            show_default=True,
+            help='Extra cell metadata table, must be tab-separated with a header '
+            'row and an index column, and with matched dimension.',
+        ),
+        click.option(
+            '--extra-var',
+            type=click.Path(exists=True, dir_okay=False),
+            default=None,
+            show_default=True,
+            help='Extra gene metadata table, must be tab-separated with a header '
+            'row and an index column, and with matched dimension.',
+        ),
+    ],
 
-FILTER_CMD_OPTIONS = [
-    *COMMON_OPTIONS['input'],
-    *COMMON_OPTIONS['output'],
-    click.option(
-        '--gene-name', '-g',
-        type=click.STRING,
-        default='index',
-        show_default=True,
-        help='Name of the variable that contains gene names, used for flagging '
-        'mitochondria genes when column "mito" is absent from `.var`.',
-    ),
-    click.option(
-        '--list-attr', '-l',
-        is_flag=True,
-        default=False,
-        help='When set, list attributes that can be filtered on.',
-    ),
-    click.option(
-        '--param', '-p',
-        type=(click.STRING, click.FLOAT, click.FLOAT),
-        multiple=True,
-        callback=valid_parameter_limits,
-        help='Numerical parameters used to filter the data, '
-        'in the format of "-p name min max". '
-        'Multiple -p entries allowed.',
-    ),
-    click.option(
-        '--category', '-c',
-        type=(click.STRING, CommaSeparatedText()),
-        multiple=True,
-        help='Categorical attributes used to filter the data, '
-        'in the format of "-c <name> <values>", '
-        'where entries with attribute <name> with value in <values> are kept. '
-        'Multiple -c entries allowed.',
-    ),
-    click.option(
-        '--subset', '-s',
-        type=(click.STRING, click.File()),
-        multiple=True,
-        help='Similar to --category in the format of "-s <name> <file>", '
-        'but the <file> to be a one-column table that provides the values. '
-        'Multiple -s entries allowed.',
-    ),
-]
+    'filter': [
+        *COMMON_OPTIONS['input'],
+        *COMMON_OPTIONS['output'],
+        click.option(
+            '--gene-name', '-g',
+            type=click.STRING,
+            default='index',
+            show_default=True,
+            help='Name of the variable that contains gene names, used for flagging '
+            'mitochondria genes when column "mito" is absent from `.var`.',
+        ),
+        click.option(
+            '--list-attr', '-l',
+            is_flag=True,
+            default=False,
+            help='When set, list attributes that can be filtered on.',
+        ),
+        click.option(
+            '--param', '-p',
+            type=(click.STRING, click.FLOAT, click.FLOAT),
+            multiple=True,
+            callback=valid_parameter_limits,
+            help='Numerical parameters used to filter the data, '
+            'in the format of "-p name min max". '
+            'Multiple -p entries allowed.',
+        ),
+        click.option(
+            '--category', '-c',
+            type=(click.STRING, CommaSeparatedText()),
+            multiple=True,
+            help='Categorical attributes used to filter the data, '
+            'in the format of "-c <name> <values>", '
+            'where entries with attribute <name> with value in <values> are kept. '
+            'Multiple -c entries allowed.',
+        ),
+        click.option(
+            '--subset', '-s',
+            type=(click.STRING, click.File()),
+            multiple=True,
+            help='Similar to --category in the format of "-s <name> <file>", '
+            'but the <file> to be a one-column table that provides the values. '
+            'Multiple -s entries allowed.',
+        ),
+    ],
 
-NORM_CMD_OPTIONS = [
-    *COMMON_OPTIONS['input'],
-    *COMMON_OPTIONS['output'],
-    click.option(
-        '--save-raw', '-r',
-        type=click.Choice(['yes', 'no', 'counts']),
-        default='yes',
-        show_default=True,
-        help='Save raw data existing raw data.',
-    ),
-    click.option(
-        '--no-log-transform', 'log_transform',
-        is_flag=True,
-        default=True,
-        show_default=True,
-        help='When set, do not apply (natural) log transform following normalisation.',
-    ),
-    click.option(
-        '--normalize-to', '-t', 'target_sum',
-        type=float,
-        default=10_000,
-        show_default=True,
-        help='Normalize per cell nUMI to this number.',
-    ),
-    click.option(
-        '--fraction',
-        type=float,
-        default=0.9,
-        show_default=True,
-        help='Only use genes that make up less than this fraction of the total '
-        'count in every cell. So only these genes will sum up to the number '
-        'specified by --normalize-to.',
-    ),
-]
+    'norm': [
+        *COMMON_OPTIONS['input'],
+        *COMMON_OPTIONS['output'],
+        click.option(
+            '--save-raw', '-r',
+            type=click.Choice(['yes', 'no', 'counts']),
+            default='yes',
+            show_default=True,
+            help='Save raw data existing raw data.',
+        ),
+        click.option(
+            '--no-log-transform', 'log_transform',
+            is_flag=True,
+            default=True,
+            show_default=True,
+            help='When set, do not apply (natural) log transform following normalisation.',
+        ),
+        click.option(
+            '--normalize-to', '-t', 'target_sum',
+            type=float,
+            default=10_000,
+            show_default=True,
+            help='Normalize per cell nUMI to this number.',
+        ),
+        click.option(
+            '--fraction',
+            type=float,
+            default=0.9,
+            show_default=True,
+            help='Only use genes that make up less than this fraction of the total '
+            'count in every cell. So only these genes will sum up to the number '
+            'specified by --normalize-to.',
+        ),
+    ],
 
-HVG_CMD_OPTIONS = [
-    *COMMON_OPTIONS['input'],
-    *COMMON_OPTIONS['output'],
-    click.option(
-        '--mean-limits', '-m',
-        type=(click.FLOAT, click.FLOAT),
-        callback=valid_limit,
-        default=(0.0125, 3),
-        show_default=True,
-        help='Cutoffs for the mean of expression'
-        'in the format of "-m min max".',
-    ),
-    click.option(
-        '--disp-limits', '-d',
-        type=(click.FLOAT, click.FLOAT),
-        callback=valid_limit,
-        default=(0.5, float('inf')),
-        show_default=True,
-        help='Cutoffs for the dispersion of expression'
-        'in the format of "-d min max".',
-    ),
-    click.option(
-        '--n-bins', '-b',
-        type=click.INT,
-        default=20,
-        show_default=True,
-        help='Number of bins for binning the mean gene expression.',
-    ),
-    click.option(
-        '--n-top-genes', '-t',
-        type=click.INT,
-        default=2000,
-        show_default=True,
-        help='Number of highly-variable genes to keep.',
-    ),
-    click.option(
-        '--flavor', '-v',
-        type=click.Choice(['seurat', 'cellranger']),
-        default='seurat',
-        show_default=True,
-        help='Choose the flavor for computing normalized dispersion.',
-    ),
-    click.option(
-        '--subset', '-s',
-        is_flag=True,
-        default=False,
-        help='When set, inplace subset to highly-variable genes, otherwise '
-        'only flag highly-variable genes.',
-    ),
-    click.option(
-        '--by-batch', '-B',
-        type=(click.STRING, click.INT),
-        default=(None, None),
-        show_default=True,
-        help='Find highly variable genes within each batch defined by <TEXT> '
-        'then pool and keep those found in at least <INTEGER> batches.',
-    ),
-]
+    'hvg': [
+        *COMMON_OPTIONS['input'],
+        *COMMON_OPTIONS['output'],
+        click.option(
+            '--mean-limits', '-m',
+            type=(click.FLOAT, click.FLOAT),
+            callback=valid_limit,
+            default=(0.0125, 3),
+            show_default=True,
+            help='Cutoffs for the mean of expression'
+            'in the format of "-m min max".',
+        ),
+        click.option(
+            '--disp-limits', '-d',
+            type=(click.FLOAT, click.FLOAT),
+            callback=valid_limit,
+            default=(0.5, float('inf')),
+            show_default=True,
+            help='Cutoffs for the dispersion of expression'
+            'in the format of "-d min max".',
+        ),
+        click.option(
+            '--n-bins', '-b',
+            type=click.INT,
+            default=20,
+            show_default=True,
+            help='Number of bins for binning the mean gene expression.',
+        ),
+        click.option(
+            '--n-top-genes', '-t',
+            type=click.INT,
+            default=2000,
+            show_default=True,
+            help='Number of highly-variable genes to keep.',
+        ),
+        click.option(
+            '--flavor', '-v',
+            type=click.Choice(['seurat', 'cellranger']),
+            default='seurat',
+            show_default=True,
+            help='Choose the flavor for computing normalized dispersion.',
+        ),
+        click.option(
+            '--subset', '-s',
+            is_flag=True,
+            default=False,
+            help='When set, inplace subset to highly-variable genes, otherwise '
+            'only flag highly-variable genes.',
+        ),
+        click.option(
+            '--by-batch', '-B',
+            type=(click.STRING, click.INT),
+            default=(None, None),
+            show_default=True,
+            help='Find highly variable genes within each batch defined by <TEXT> '
+            'then pool and keep those found in at least <INTEGER> batches.',
+        ),
+    ],
 
-SCALE_CMD_OPTIONS = [
-    *COMMON_OPTIONS['input'],
-    *COMMON_OPTIONS['output'],
-    COMMON_OPTIONS['zero_center'],
-    click.option(
-        '--max-value', '-m',
-        type=click.FLOAT,
-        default=None,
-        show_default=True,
-        help='When specified, clip to this value after scaling, otherwise do '
-        'not clip',
-    ),
-]
-
-REGRESS_CMD_OPTIONS = [
-    *COMMON_OPTIONS['input'],
-    *COMMON_OPTIONS['output'],
-    COMMON_OPTIONS['n_jobs'],
-    click.option(
-        '--keys', '-k',
-        type=CommaSeparatedText(simplify=True),
-        default=None,
-        show_default=True,
-        help='Key(s) for observation annotation on which to regress.',
-    ),
-]
-
-PCA_CMD_OPTIONS = [
-    *COMMON_OPTIONS['input'],
-    *COMMON_OPTIONS['output'],
-    COMMON_OPTIONS['zero_center'],
-    COMMON_OPTIONS['random_state'],
-    COMMON_OPTIONS['export_embedding'],
-    COMMON_OPTIONS['n_comps'],
-    click.option(
-        '--svd-solver', '-V',
-        type=click.Choice(['auto', 'arpack', 'randomized']),
-        default='auto',
-        show_default=True,
-        help='SVD solver to use.'
-    ),
-    click.option(
-        '--use-all', '-a', 'use_highly_variable',
-        is_flag=True,
-        flag_value=False,
-        default=True,
-        help='When set, use all genes for PCA, otherwise use '
-        'highly-variable genes by default.'
-    ),
-    click.option(
-        '--chunked', '-K',
-        is_flag=True,
-        default=False,
-        help='When set, perform an incremental PCA on segments of '
-        '--chunk-size, which automatically zero centers and ignore settings of '
-        '--random-state and --svd-solver.',
-    ),
-    click.option(
-        '--chunk-size', '-Z',
-        type=click.INT,
-        callback=required_by('--chunked'),
-        default=None,
-        show_default=True,
-        help='Number of observations to include in each chunk, required by '
-        '--chunked.',
-    ),
-]
-
-NEIGHBOR_CMD_OPTIONS = [
-    *COMMON_OPTIONS['input'],
-    *COMMON_OPTIONS['output'],
-    *COMMON_OPTIONS['use_pc'],
-    COMMON_OPTIONS['key_added'],
-    COMMON_OPTIONS['random_state'],
-    click.option(
-        '--n-neighbors', '-k',
-        type=CommaSeparatedText(click.INT, simplify=True),
-        default=15,
-        show_default=True,
-        help='The size of local neighborhood (in terms of number of '
-        'neighboring data points) used for manifold approximation. Larger '
-        'values result in more global views of the manifold, while smaller '
-        'values result in more local data being preserved. In general values '
-        'should be in the range 2 to 100.  If --knn is set, number of nearest '
-        'neighbors to be searched, othwise a Gaussian kernel width is set to '
-        'the distance of the --n-neighbors neighbor.',
-    ),
-    click.option(
-        '--no-knn', 'knn',
-        is_flag=True,
-        flag_value=False,
-        default=True,
-        show_default=True,
-        help='When NOT set, use a hard threshold to restrict the number of '
-        'neighbors to --n-neighbors. Otherwise, use a Gaussian kernel to '
-        'assign low weights to neighbors more distant than the --n-neighbors '
-        'nearest neighbor',
-    ),
-    click.option(
-        '--method', '-m',
-        type=click.Choice(['umap', 'gauss']),
-        default='umap',
-        show_default=True,
-        help='Use umap or gauss with adaptive width for computing '
-        'connectivities.'
-    ),
-]
-
-UMAP_CMD_OPTIONS = [
-    *COMMON_OPTIONS['input'],
-    *COMMON_OPTIONS['output'],
-    COMMON_OPTIONS['knn_graph'][0], # --use-graph
-    COMMON_OPTIONS['random_state'],
-    COMMON_OPTIONS['key_added'],
-    COMMON_OPTIONS['export_embedding'],
-    click.option(
-        '--init-pos',
-        type=click.STRING,
-        default='spectral',
-        show_default=True,
-        help='How to initialize the low dimensional embedding. Can be '
-        '"spectral", "paga" or "random", or any key of `.obsm`.',
-    ),
-    click.option(
-        '--min-dist',
-        type=click.FLOAT,
-        default=0.5,
-        show_default=True,
-        help='The effective minimum distance between embedded points. Smaller '
-        'values will result in a more clustered embedding, while larger values '
-        'will results in a more even dispersal of points.',
-    ),
-    click.option(
-        '--spread',
-        type=click.FLOAT,
-        default=1.0,
-        show_default=True,
-        help='The effective scale of embedded points, which determines the '
-        'scale at which embedded points will be spread out.',
-    ),
-    click.option(
-        '--n-components',
-        type=click.INT,
-        default=2,
-        show_default=True,
-        help='The number of dimensions of the embedding.',
-    ),
-    click.option(
-        '--maxiter',
-        type=click.INT,
-        default=None,
-        show_default=True,
-        help='The number of iterations of the optimization.',
-    ),
-    click.option(
-        '--alpha',
-        type=click.FLOAT,
-        default=1.0,
-        show_default=True,
-        help='The initial learning rate for the embedding optimization.',
-    ),
-    click.option(
-        '--gamma',
-        type=click.FLOAT,
-        default=1.0,
-        show_default=True,
-        help='Weighting applied to negative samples in low dimensional '
-        'embedding optimization.',
-    ),
-    click.option(
-        '--negative-sample-rate',
-        type=click.INT,
-        default=5,
-        show_default=True,
-        help='The number of negative edge samples to use per positive edge '
-        'sample in optimizing the low dimensional embedding.',
-    ),
-]
-
-TSNE_CMD_OPTIONS = [
-    *COMMON_OPTIONS['input'],
-    *COMMON_OPTIONS['output'],
-    *COMMON_OPTIONS['use_pc'],
-    COMMON_OPTIONS['random_state'],
-    COMMON_OPTIONS['key_added'],
-    COMMON_OPTIONS['n_jobs'],
-    COMMON_OPTIONS['export_embedding'],
-    click.option(
-        '--perplexity',
-        type=click.FLOAT,
-        default=30,
-        show_default=True,
-        help='The perplexity is related to the number of nearest neighbors '
-        'that is used in other manifold learning algorithms. Larger datasets '
-        'usually require a larger perplexity. Consider selecting a value '
-        'between 5 and 50. The choice is not extremely critical since t-SNE '
-        'is quite insensitive to this parameter.',
-    ),
-    click.option(
-        '--early-exaggeration',
-        type=click.FLOAT,
-        default=12,
-        show_default=True,
-        help='Controls how tight natural clusters in the original space are in '
-        'the embedded space and how much space will be between them. For '
-        'larger values, the space between natural clusters will be larger in '
-        'the embedded space. Again, the choice of this parameter is not very '
-        'critical. If the cost function increases during initial optimization, '
-        'the early exaggeration factor or the learning rate might be too high.',
-    ),
-    click.option(
-        '--learning-rate',
-        type=click.FLOAT,
-        default=1000,
-        show_default=True,
-        help='Note that the R-package "Rtsne" uses a default of 200. The '
-        'learning rate can be a critical parameter. It should be between 100 '
-        'and 1000. If the cost function increases during initial optimization, '
-        'the early exaggeration factor or the learning rate might be too high. '
-        'If the cost function gets stuck in a bad local minimum increasing the '
-        'learning rate helps sometimes.',
-    ),
-    click.option(
-        '--no-fast-tsne', 'use_fast_tsne',
-        is_flag=True,
-        flag_value=False,
-        default=True,
-        show_default=True,
-        help='When NOT set, use the MulticoreTSNE package by D. Ulyanov if '
-        'installed.',
-    ),
-]
-
-FDG_CMD_OPTIONS = [
-    *COMMON_OPTIONS['input'],
-    *COMMON_OPTIONS['output'],
-    COMMON_OPTIONS['knn_graph'][0], # --use-graph
-    COMMON_OPTIONS['random_state'],
-    COMMON_OPTIONS['key_added'],
-    COMMON_OPTIONS['export_embedding'],
-    click.option(
-        '--init-pos',
-        type=click.STRING,
-        default=None,
-        help='Use precomputed coordinates for initialization. Can be any key '
-        'of `.obsm` or "paga" if .uns["paga"] is present',
-    ),
-    click.option(
-        '--layout',
-        type=click.Choice(['fa', 'fr', 'grid_fr', 'kk', 'lgl', 'drl', 'rt']),
-        default='fa',
-        show_default=True,
-        help='Name of any valid igraph layout, including "fa" (ForceAtlas2), '
-        '"fr" (Fruchterman Reingold), "grid_fr" (Grid Fruchterman Reingold, '
-        'faster than "fr"), "kk" (Kamadi Kawai, slower than "fr"), "lgl" '
-        '(Large Graph Layout, very fast), "drl" (Distributed Recursive Layout, '
-        'pretty fast) and "rt" (Reingold Tilford tree layout).',
-    ),
-    click.option(
-        '--init-pos',
-        type=click.STRING,
-        default=None,
-        show_default=True,
-        help='How to initialize the low dimensional embedding. Can be "paga", '
-        'or any valid key of `.obsm`.',
-    ),
-]
-
-LOUVAIN_CMD_OPTIONS = [
-    *COMMON_OPTIONS['input'],
-    *COMMON_OPTIONS['output'],
-    COMMON_OPTIONS['export_cluster'],
-    *COMMON_OPTIONS['knn_graph'],
-    COMMON_OPTIONS['restrict_to'],
-    COMMON_OPTIONS['random_state'],
-    COMMON_OPTIONS['key_added'],
-    click.option(
-        '--flavor',
-        type=click.Choice(['vtraag', 'igraph']),
-        default='vtraag',
-        show_default=True,
-        help='Choose between two packages for computing the clustering. '
-        '"vtraag" is much powerful, and the default.',
-    ),
-    click.option(
-        '--resolution', '-r',
-        type=CommaSeparatedText(click.FLOAT, simplify=True),
-        default=1,
-        show_default=True,
-        help='For the default flavor "vtraag", you can provide a resolution. '
-        'Higher resolution means finding more and smaller clusters.',
-    ),
-]
-
-LEIDEN_CMD_OPTIONS = [
-    *COMMON_OPTIONS['input'],
-    *COMMON_OPTIONS['output'],
-    COMMON_OPTIONS['export_cluster'],
-    *COMMON_OPTIONS['knn_graph'],
-    COMMON_OPTIONS['restrict_to'],
-    COMMON_OPTIONS['random_state'],
-    COMMON_OPTIONS['key_added'],
-    click.option(
-        '--resolution', '-r',
-        type=CommaSeparatedText(click.FLOAT, simplify=True),
-        default=1,
-        show_default=True,
-        help='A parameter value controlling the coarseness of the clustering. '
-        'Higher values lead to more clusters. Set to "None" if overriding '
-        '--partition_type to one that doesn\'t accept `resolution_parameter`.',
-    ),
-    click.option(
-        '--n-iterations',
-        type=click.INT,
-        default=-1,
-        show_default=True,
-        help='How many iterations of the Leiden clustering algorithm to '
-        'perform. -1 has the algorithm run until it reaches its optimal '
-        'clustering.',
-    ),
-]
-
-DIFFEXP_CMD_OPTIONS = [
-    *COMMON_OPTIONS['input'],
-    *COMMON_OPTIONS['output'],
-    COMMON_OPTIONS['use_raw'],
-    click.option(
-        '--groupby', '-g',
-        type=click.STRING,
-        required=True,
-        help='The key of the observations grouping to consider.',
-    ),
-    click.option(
-        '--groups',
-        type=CommaSeparatedText(simplify=True),
-        default='all',
-        show_default=True,
-        help='Subset of groups to which comparison shall be restricted.',
-    ),
-    click.option(
-        '--reference',
-        type=click.STRING,
-        default='rest',
-        show_default=True,
-        help='If "rest", compare each group to the union of the rest of the '
-        'groups. If a group identifier, compare with respect to this group.',
-    ),
-    click.option(
-        '--n-genes', '-n',
-        type=click.INT,
-        default=None,
-        show_default=True,
-        help='The number of genes that appear in the retured tables. By '
-        'default return all available genes depending on the value of '
-        '--use-raw.'
-    ),
-    click.option(
-        '--method',
-        type=click.Choice(
-            ['logreg', 't-test', 'wilcoxon', 't-test_overestim_var']),
-        default='t-test_overestim_var',
-        show_default=True,
-        help='Method of performing differential expression analysis.',
-    ),
-    click.option(
-        '--corr-method',
-        type=click.Choice(['benjamini-hochberg', 'bonferroni']),
-        default='benjamini-hochberg',
-        show_default=True,
-        help='P-value correction method. Used only for "t-test", '
-        '"t-test_overestim_var" and "wilcoxon".',
-    ),
-    click.option(
-        '--rankby-abs',
-        is_flag=True,
-        default=False,
-        show_default=True,
-        help='Rank genes by the absolute value of the score, not by the score. '
-        'The returned scores are never the absolute values.',
-    ),
-    click.option(
-        '--filter-params',
-        type=Dictionary(keys=[
-            'min_in_group_fraction',
-            'max_out_group_fraction',
-            'min_fold_change',
-        ]),
-        default=None,
-        show_default=True,
-        help='Parameters for filtering DE results, valid parameters are: '
-        '"min_in_group_fraction" (float), "max_out_group_fraction" (float), '
-        '"min_fold_change" (float).',
-    ),
-    click.option(
-        '--logreg-param',
-        type=Dictionary(),
-        default=None,
-        show_default=True,
-        help='Parameters passed to `sklearn.linear_model.LogisticRegression`.',
-    ),
-    click.option(
-        '--save',
-        type=click.Path(dir_okay=False, writable=True),
-        default=None,
-        show_default=True,
-        help='Tab-separated table to store results of differential expression '
-        'analysis.',
-    ),
-]
-
-PAGA_CMD_OPTIONS = [
-    *COMMON_OPTIONS['input'],
-    *COMMON_OPTIONS['output'],
-    COMMON_OPTIONS['knn_graph'][0], # --use-graph
-    COMMON_OPTIONS['key_added'],
-    click.option(
-        '--groups',
-        type=click.STRING,
-        required=True,
-        help='Key for categorical in `.obs`. You can pass your predefined '
-        'groups by choosing any categorical annotation of observations.',
-    ),
-    click.option(
-        '--model',
-        type=click.Choice(['v1.2', 'v1.0']),
-        default='v1.2',
-        show_default=True,
-        help='The PAGA connectivity model.',
-    ),
-]
-
-DIFFMAP_CMD_OPTIONS = [
-    *COMMON_OPTIONS['input'],
-    *COMMON_OPTIONS['output'],
-    COMMON_OPTIONS['knn_graph'][0], # --use-graph
-    COMMON_OPTIONS['key_added'],
-    COMMON_OPTIONS['export_embedding'],
-    COMMON_OPTIONS['n_comps'],
-]
-
-DPT_CMD_OPTIONS = [
-    *COMMON_OPTIONS['input'],
-    *COMMON_OPTIONS['output'],
-    COMMON_OPTIONS['knn_graph'][0], # --use-graph
-    COMMON_OPTIONS['key_added'],
-    click.option(
-        '--root',
-        type=(click.STRING, click.STRING),
-        default=(None, None),
-        show_default=True,
-        help='Specify a categorical annotaion of observations (`.obs`) and a '
-        'value representing the root cells.',
-    ),
-    click.option(
-        '--n-dcs',
-        type=click.INT,
-        default=10,
-        show_default=True,
-        help='The number of diffusion components to use.',
-    ),
-    click.option(
-        '--n-branchings',
-        type=click.INT,
-        default=0,
-        show_default=True,
-        help='Number of branchings to detect.',
-    ),
-    click.option(
-        '--min-group-size',
-        type=click.FLOAT,
-        default=0.01,
-        show_default=True,
-        help='During recursive splitting of branches for --n-branchings > 1, '
-        'do not consider branches/groups that contain fewer than this fraction '
-        'of the total number of data points.',
-    ),
-]
-
-PLOT_EMBED_CMD_OPTIONS = [
-    *COMMON_OPTIONS['input'],
-    *COMMON_OPTIONS['plot'],
-    *COMMON_OPTIONS['frame_title'],
-    click.option(
-        '--basis',
-        type=click.STRING,
-        default='umap',
-        show_default=True,
-        help='Name of the embedding to plot, must be a key of `.obsm` without '
-        'the prefix "X_".',
-    ),
-    click.option(
-        '--color',
-        type=CommaSeparatedText(simplify=True),
-        default=None,
-        show_default=True,
-        help='Keys for annotations of observations/cells or variables/genes.',
-    ),
-    click.option(
-        '--use-raw/--no-raw',
-        default=None,
-        show_default=True,
-        help='Use `.raw` attribute for coloring with gene expression. If '
-        '`None`, uses `.raw` if present.',
-    ),
-    click.option(
-        '--legend-loc',
-        type=click.Choice(['right margin', 'on data']),
-        default='right margin',
-        show_default=True,
-        help='Location of legend, either "on data", "right margin" or valid '
-        'keywords for `matplotlib.legend`.',
-    ),
-    click.option(
-        '--legend-fontsize',
-        type=click.INT,
-        default=15,
-        show_default=True,
-        help='Legend font size.',
-    ),
-    click.option(
-        '--size',
-        type=click.FLOAT,
-        default=None,
-        show_default=True,
-        help='Point size. Automatically computed if not specified.',
-    ),
-]
-
-PLOT_STACKED_VIOLIN_CMD_OPTIONS = [
-    *COMMON_OPTIONS['input'],
-    *COMMON_OPTIONS['plot'],
-    COMMON_OPTIONS['use_raw'],
-    COMMON_OPTIONS['var_names'],
-    *COMMON_OPTIONS['diffexp_plot'],
-    *COMMON_OPTIONS['stacked_violin'],
-    COMMON_OPTIONS['swap_axes'],
-]
-
-PLOT_RANK_GENE_GROUPS_STACKED_VIOLIN_CMD_OPTIONS = [
-    *COMMON_OPTIONS['input'],
-    *COMMON_OPTIONS['plot'],
-    COMMON_OPTIONS['use_raw'],
-    *COMMON_OPTIONS['rank_genes_groups_plots'],
-    *COMMON_OPTIONS['diffexp_plot'],
-    *COMMON_OPTIONS['stacked_violin'],
-    COMMON_OPTIONS['swap_axes'],
-]   
-
-PLOT_DOT_CMD_OPTIONS = [
-    *COMMON_OPTIONS['input'],
-    *COMMON_OPTIONS['plot'],
-    COMMON_OPTIONS['use_raw'],
-    COMMON_OPTIONS['var_names'],
-    *COMMON_OPTIONS['diffexp_plot'],
-    click.option(
-        '--expression-cutoff',
-        type=click.FLOAT,
-        default=0,
-        show_default=True,
-        help='Expression cutoff that is used for binarizing the gene expression '
-        'and determining the fraction of cells expressing given genes. A gene is '
-        'expressed only if the expression value is greater than this threshold.'
-    ),
-    click.option(
-        '--mean-only-expressed',
-        is_flag=True,
-        default=False,
-        show_default=True,
-        help='If True, gene expression is averaged only over the cells '
-        'expressing the given genes.',
-    ),
-    click.option(
-        '--color-map',
-        type=CommaSeparatedText(simplify=True),
-        default='Reds',
-        show_default=True,
-        help='String denoting matplotlib color map.',
-    ),
-    click.option(
-        '--dot-max',
-        type=click.FLOAT,
-        default=None,
-        show_default=True,
-        help='If none, the maximum dot size is set to the maximum fraction '
-        'value found (e.g. 0.6). If given, the value should be a number between '
-        '0 and 1. All fractions larger than dot_max are clipped to this value.'
-    ),
-    click.option(
-        '--dot-min',
-        type=click.FLOAT,
-        default=None,
-        show_default=True,
-        help='If none, the minimum dot size is set to 0. If given, the value '
-        'should be a number between 0 and 1. All fractions smaller than dot_min '
-        'are clipped to this value.'
-    ),
-    click.option(
-        '--smallest-dot',
-        type=click.FLOAT,
-        default=0,
-        show_default=True,
-        help='If none, the smallest dot has size 0. All expression levels with '
-        'dot_min are potted with smallest_dot dot size.'
-    ),
-]
-
-PLOT_MATRIX_CMD_OPTIONS = [
-    *COMMON_OPTIONS['input'],
-    *COMMON_OPTIONS['plot'],
-    COMMON_OPTIONS['use_raw'],
-    COMMON_OPTIONS['var_names'],
-    *COMMON_OPTIONS['diffexp_plot'],
-]
-
-PLOT_RANK_GENE_GROUPS_MATRIX_CMD_OPTIONS = [
-    *COMMON_OPTIONS['input'],
-    *COMMON_OPTIONS['plot'],
-    COMMON_OPTIONS['use_raw'],
-    *COMMON_OPTIONS['rank_genes_groups_plots'],
-    *COMMON_OPTIONS['diffexp_plot'],
-]   
+    'scale': [
+        *COMMON_OPTIONS['input'],
+        *COMMON_OPTIONS['output'],
+        COMMON_OPTIONS['zero_center'],
+        click.option(
+            '--max-value', '-m',
+            type=click.FLOAT,
+            default=None,
+            show_default=True,
+            help='When specified, clip to this value after scaling, otherwise do '
+            'not clip',
+        ),
+    ],
     
-PLOT_PAGA_CMD_OPTIONS = [
-    *COMMON_OPTIONS['input'],
-    *COMMON_OPTIONS['plot'],
-    *COMMON_OPTIONS['frame_title'],
-    click.option(
-        '--use-key',
-        type=click.STRING,
-        default='paga',
-        show_default=True,
-        help='The key in `.uns` that contains trajectory information.',
-    ),
-    click.option(
-        '--layout',
-        type=click.Choice(['fa', 'fr', 'grid_fr', 'kk', 'lgl', 'drl', 'rt']),
-        default='fr',
-        show_default=True,
-        help='Plotting layout that computes positions.',
-    ),
-    click.option(
-        '--init-pos',
-        type=click.STRING,
-        default=None,
-        show_default=True,
-        help='Plotting layout that computes positions.',
-    ),
-    click.option(
-        '--threshold',
-        type=click.FLOAT,
-        default=0.01,
-        show_default=True,
-        help='Do not draw edges for weights below this threshold. Set to 0 to '
-        'include all edges.',
-    ),
-    click.option(
-        '--root',
-        type=click.INT,
-        default=0,
-        show_default=True,
-        help='If choosing a tree layout, this is the index of the root node.',
-    ),
-    click.option(
-        '--transitions',
-        type=click.STRING,
-        default=None,
-        show_default=True,
-        help='Key for `.uns["paga"]` that specifies the matrix, e.g. '
-        '`transition_confidence`, that stores the arrows.',
-    ),
-    click.option(
-        '--single-component',
-        is_flag=True,
-        default=False,
-        show_default=True,
-        help='Restrict to largest connected component',
-    ),
-    click.option(
-        '--solid-edges',
-        type=click.Choice(['connectivities', 'connectivities_tree']),
-        default='connectivities',
-        show_default=True,
-        help='Key for `.uns["paga"]` that specifies the matrix that stores the '
-        'edges to be drawn solid black.',
-    ),
-    click.option(
-        '--basis',
-        type=click.STRING,
-        default=None,
-        show_default=True,
-        help='Name of the embedding to plot, must be a key of `.obsm` without '
-        'the prefix "X_".',
-    ),
-    click.option(
-        '--color',
-        type=click.STRING,
-        default=None,
-        show_default=True,
-        help='Key for annotation of observations/cells or variables/genes.',
-    ),
-    click.option(
-        '--legend-loc',
-        type=click.Choice(['right margin', 'on data']),
-        default='right margin',
-        show_default=True,
-        help='Location of legend, either "on data", "right margin" or valid '
-        'keywords for `matplotlib.legend`.',
-    ),
-    click.option(
-        '--size',
-        type=click.FLOAT,
-        default=None,
-        show_default=True,
-        help='Point size. Automatically computed if not specified.',
-    ),
-    click.option(
-        '--node-size-scale',
-        type=click.FLOAT,
-        default=1.0,
-        show_default=True,
-        help='Increase of decrease the size of the nodes.',
-    ),
-    click.option(
-        '--fontsize',
-        type=click.INT,
-        default=None,
-        show_default=True,
-        help='Font size for node labels.',
-    ),
-    click.option(
-        '--edge-width-scale',
-        type=click.FLOAT,
-        default=1.0,
-        show_default=True,
-        help='Increase of decrease the width of the edges.',
-    ),
-    click.option(
-        '--arrowsize',
-        type=click.INT,
-        default=30,
-        show_default=True,
-        help='For directed graphs, specify the length and width of the arrowhead.',
-    ),
-]
+    'regress': [
+        *COMMON_OPTIONS['input'],
+        *COMMON_OPTIONS['output'],
+        COMMON_OPTIONS['n_jobs'],
+        click.option(
+            '--keys', '-k',
+            type=CommaSeparatedText(simplify=True),
+            default=None,
+            show_default=True,
+            help='Key(s) for observation annotation on which to regress.',
+        ),
+    ],
 
-PLOT_HEATMAP_CMD_OPTIONS = [
-    *COMMON_OPTIONS['input'],
-    *COMMON_OPTIONS['plot'],
-    COMMON_OPTIONS['use_raw'],
-    COMMON_OPTIONS['var_names'],
-    *COMMON_OPTIONS['diffexp_plot'],
-    *COMMON_OPTIONS['heatmap'],
-    COMMON_OPTIONS['swap_axes'],
-]
+    'pca': [
+        *COMMON_OPTIONS['input'],
+        *COMMON_OPTIONS['output'],
+        COMMON_OPTIONS['zero_center'],
+        COMMON_OPTIONS['random_state'],
+        COMMON_OPTIONS['export_embedding'],
+        COMMON_OPTIONS['n_comps'],
+        click.option(
+            '--svd-solver', '-V',
+            type=click.Choice(['auto', 'arpack', 'randomized']),
+            default='auto',
+            show_default=True,
+            help='SVD solver to use.'
+        ),
+        click.option(
+            '--use-all', '-a', 'use_highly_variable',
+            is_flag=True,
+            flag_value=False,
+            default=True,
+            help='When set, use all genes for PCA, otherwise use '
+            'highly-variable genes by default.'
+        ),
+        click.option(
+            '--chunked', '-K',
+            is_flag=True,
+            default=False,
+            help='When set, perform an incremental PCA on segments of '
+            '--chunk-size, which automatically zero centers and ignore settings of '
+            '--random-state and --svd-solver.',
+        ),
+        click.option(
+            '--chunk-size', '-Z',
+            type=click.INT,
+            callback=required_by('--chunked'),
+            default=None,
+            show_default=True,
+            help='Number of observations to include in each chunk, required by '
+            '--chunked.',
+        ),
+    ],
 
-PLOT_RANK_GENE_GROUPS_HEATMAP_CMD_OPTIONS = [
-    *COMMON_OPTIONS['input'],
-    *COMMON_OPTIONS['plot'],
-    COMMON_OPTIONS['use_raw'],
-    *COMMON_OPTIONS['rank_genes_groups_plots'],
-    *COMMON_OPTIONS['diffexp_plot'],
-    *COMMON_OPTIONS['heatmap'],
-    COMMON_OPTIONS['swap_axes'],
-]   
+    'neighbor': [
+        *COMMON_OPTIONS['input'],
+        *COMMON_OPTIONS['output'],
+        *COMMON_OPTIONS['use_pc'],
+        COMMON_OPTIONS['key_added'],
+        COMMON_OPTIONS['random_state'],
+        click.option(
+            '--n-neighbors', '-k',
+            type=CommaSeparatedText(click.INT, simplify=True),
+            default=15,
+            show_default=True,
+            help='The size of local neighborhood (in terms of number of '
+            'neighboring data points) used for manifold approximation. Larger '
+            'values result in more global views of the manifold, while smaller '
+            'values result in more local data being preserved. In general values '
+            'should be in the range 2 to 100.  If --knn is set, number of nearest '
+            'neighbors to be searched, othwise a Gaussian kernel width is set to '
+            'the distance of the --n-neighbors neighbor.',
+        ),
+        click.option(
+            '--no-knn', 'knn',
+            is_flag=True,
+            flag_value=False,
+            default=True,
+            show_default=True,
+            help='When NOT set, use a hard threshold to restrict the number of '
+            'neighbors to --n-neighbors. Otherwise, use a Gaussian kernel to '
+            'assign low weights to neighbors more distant than the --n-neighbors '
+            'nearest neighbor',
+        ),
+        click.option(
+            '--method', '-m',
+            type=click.Choice(['umap', 'gauss']),
+            default='umap',
+            show_default=True,
+            help='Use umap or gauss with adaptive width for computing '
+            'connectivities.'
+        ),
+    ],
+
+    'umap': [
+        *COMMON_OPTIONS['input'],
+        *COMMON_OPTIONS['output'],
+        COMMON_OPTIONS['knn_graph'][0], # --use-graph
+        COMMON_OPTIONS['random_state'],
+        COMMON_OPTIONS['key_added'],
+        COMMON_OPTIONS['export_embedding'],
+        click.option(
+            '--init-pos',
+            type=click.STRING,
+            default='spectral',
+            show_default=True,
+            help='How to initialize the low dimensional embedding. Can be '
+            '"spectral", "paga" or "random", or any key of `.obsm`.',
+        ),
+        click.option(
+            '--min-dist',
+            type=click.FLOAT,
+            default=0.5,
+            show_default=True,
+            help='The effective minimum distance between embedded points. Smaller '
+            'values will result in a more clustered embedding, while larger values '
+            'will results in a more even dispersal of points.',
+        ),
+        click.option(
+            '--spread',
+            type=click.FLOAT,
+            default=1.0,
+            show_default=True,
+            help='The effective scale of embedded points, which determines the '
+            'scale at which embedded points will be spread out.',
+        ),
+        click.option(
+            '--n-components',
+            type=click.INT,
+            default=2,
+            show_default=True,
+            help='The number of dimensions of the embedding.',
+        ),
+        click.option(
+            '--maxiter',
+            type=click.INT,
+            default=None,
+            show_default=True,
+            help='The number of iterations of the optimization.',
+        ),
+        click.option(
+            '--alpha',
+            type=click.FLOAT,
+            default=1.0,
+            show_default=True,
+            help='The initial learning rate for the embedding optimization.',
+        ),
+        click.option(
+            '--gamma',
+            type=click.FLOAT,
+            default=1.0,
+            show_default=True,
+            help='Weighting applied to negative samples in low dimensional '
+            'embedding optimization.',
+        ),
+        click.option(
+            '--negative-sample-rate',
+            type=click.INT,
+            default=5,
+            show_default=True,
+            help='The number of negative edge samples to use per positive edge '
+            'sample in optimizing the low dimensional embedding.',
+        ),
+    ],
+
+    'tsne': [
+        *COMMON_OPTIONS['input'],
+        *COMMON_OPTIONS['output'],
+        *COMMON_OPTIONS['use_pc'],
+        COMMON_OPTIONS['random_state'],
+        COMMON_OPTIONS['key_added'],
+        COMMON_OPTIONS['n_jobs'],
+        COMMON_OPTIONS['export_embedding'],
+        click.option(
+            '--perplexity',
+            type=click.FLOAT,
+            default=30,
+            show_default=True,
+            help='The perplexity is related to the number of nearest neighbors '
+            'that is used in other manifold learning algorithms. Larger datasets '
+            'usually require a larger perplexity. Consider selecting a value '
+            'between 5 and 50. The choice is not extremely critical since t-SNE '
+            'is quite insensitive to this parameter.',
+        ),
+        click.option(
+            '--early-exaggeration',
+            type=click.FLOAT,
+            default=12,
+            show_default=True,
+            help='Controls how tight natural clusters in the original space are in '
+            'the embedded space and how much space will be between them. For '
+            'larger values, the space between natural clusters will be larger in '
+            'the embedded space. Again, the choice of this parameter is not very '
+            'critical. If the cost function increases during initial optimization, '
+            'the early exaggeration factor or the learning rate might be too high.',
+        ),
+        click.option(
+            '--learning-rate',
+            type=click.FLOAT,
+            default=1000,
+            show_default=True,
+            help='Note that the R-package "Rtsne" uses a default of 200. The '
+            'learning rate can be a critical parameter. It should be between 100 '
+            'and 1000. If the cost function increases during initial optimization, '
+            'the early exaggeration factor or the learning rate might be too high. '
+            'If the cost function gets stuck in a bad local minimum increasing the '
+            'learning rate helps sometimes.',
+        ),
+        click.option(
+            '--no-fast-tsne', 'use_fast_tsne',
+            is_flag=True,
+            flag_value=False,
+            default=True,
+            show_default=True,
+            help='When NOT set, use the MulticoreTSNE package by D. Ulyanov if '
+            'installed.',
+        ),
+    ],
+
+    'fdg': [
+        *COMMON_OPTIONS['input'],
+        *COMMON_OPTIONS['output'],
+        COMMON_OPTIONS['knn_graph'][0], # --use-graph
+        COMMON_OPTIONS['random_state'],
+        COMMON_OPTIONS['key_added'],
+        COMMON_OPTIONS['export_embedding'],
+        click.option(
+            '--init-pos',
+            type=click.STRING,
+            default=None,
+            help='Use precomputed coordinates for initialization. Can be any key '
+            'of `.obsm` or "paga" if .uns["paga"] is present',
+        ),
+        click.option(
+            '--layout',
+            type=click.Choice(['fa', 'fr', 'grid_fr', 'kk', 'lgl', 'drl', 'rt']),
+            default='fa',
+            show_default=True,
+            help='Name of any valid igraph layout, including "fa" (ForceAtlas2), '
+            '"fr" (Fruchterman Reingold), "grid_fr" (Grid Fruchterman Reingold, '
+            'faster than "fr"), "kk" (Kamadi Kawai, slower than "fr"), "lgl" '
+            '(Large Graph Layout, very fast), "drl" (Distributed Recursive Layout, '
+            'pretty fast) and "rt" (Reingold Tilford tree layout).',
+        ),
+        click.option(
+            '--init-pos',
+            type=click.STRING,
+            default=None,
+            show_default=True,
+            help='How to initialize the low dimensional embedding. Can be "paga", '
+            'or any valid key of `.obsm`.',
+        ),
+    ],
+
+    'louvain': [
+        *COMMON_OPTIONS['input'],
+        *COMMON_OPTIONS['output'],
+        COMMON_OPTIONS['export_cluster'],
+        *COMMON_OPTIONS['knn_graph'],
+        COMMON_OPTIONS['restrict_to'],
+        COMMON_OPTIONS['random_state'],
+        COMMON_OPTIONS['key_added'],
+        click.option(
+            '--flavor',
+            type=click.Choice(['vtraag', 'igraph']),
+            default='vtraag',
+            show_default=True,
+            help='Choose between two packages for computing the clustering. '
+            '"vtraag" is much powerful, and the default.',
+        ),
+        click.option(
+            '--resolution', '-r',
+            type=CommaSeparatedText(click.FLOAT, simplify=True),
+            default=1,
+            show_default=True,
+            help='For the default flavor "vtraag", you can provide a resolution. '
+            'Higher resolution means finding more and smaller clusters.',
+        ),
+    ],
+
+    'leiden': [
+        *COMMON_OPTIONS['input'],
+        *COMMON_OPTIONS['output'],
+        COMMON_OPTIONS['export_cluster'],
+        *COMMON_OPTIONS['knn_graph'],
+        COMMON_OPTIONS['restrict_to'],
+        COMMON_OPTIONS['random_state'],
+        COMMON_OPTIONS['key_added'],
+        click.option(
+            '--resolution', '-r',
+            type=CommaSeparatedText(click.FLOAT, simplify=True),
+            default=1,
+            show_default=True,
+            help='A parameter value controlling the coarseness of the clustering. '
+            'Higher values lead to more clusters. Set to "None" if overriding '
+            '--partition_type to one that doesn\'t accept `resolution_parameter`.',
+        ),
+        click.option(
+            '--n-iterations',
+            type=click.INT,
+            default=-1,
+            show_default=True,
+            help='How many iterations of the Leiden clustering algorithm to '
+            'perform. -1 has the algorithm run until it reaches its optimal '
+            'clustering.',
+        ),
+    ],
+
+    'diffexp': [
+        *COMMON_OPTIONS['input'],
+        *COMMON_OPTIONS['output'],
+        COMMON_OPTIONS['use_raw'],
+        click.option(
+            '--groupby', '-g',
+            type=click.STRING,
+            required=True,
+            help='The key of the observations grouping to consider.',
+        ),
+        click.option(
+            '--groups',
+            type=CommaSeparatedText(simplify=True),
+            default='all',
+            show_default=True,
+            help='Subset of groups to which comparison shall be restricted.',
+        ),
+        click.option(
+            '--reference',
+            type=click.STRING,
+            default='rest',
+            show_default=True,
+            help='If "rest", compare each group to the union of the rest of the '
+            'groups. If a group identifier, compare with respect to this group.',
+        ),
+        click.option(
+            '--n-genes', '-n',
+            type=click.INT,
+            default=None,
+            show_default=True,
+            help='The number of genes that appear in the retured tables. By '
+            'default return all available genes depending on the value of '
+            '--use-raw.'
+        ),
+        click.option(
+            '--method',
+            type=click.Choice(
+                ['logreg', 't-test', 'wilcoxon', 't-test_overestim_var']),
+            default='t-test_overestim_var',
+            show_default=True,
+            help='Method of performing differential expression analysis.',
+        ),
+        click.option(
+            '--corr-method',
+            type=click.Choice(['benjamini-hochberg', 'bonferroni']),
+            default='benjamini-hochberg',
+            show_default=True,
+            help='P-value correction method. Used only for "t-test", '
+            '"t-test_overestim_var" and "wilcoxon".',
+        ),
+        click.option(
+            '--rankby-abs',
+            is_flag=True,
+            default=False,
+            show_default=True,
+            help='Rank genes by the absolute value of the score, not by the score. '
+            'The returned scores are never the absolute values.',
+        ),
+        click.option(
+            '--filter-params',
+            type=Dictionary(keys=[
+                'min_in_group_fraction',
+                'max_out_group_fraction',
+                'min_fold_change',
+            ]),
+            default=None,
+            show_default=True,
+            help='Parameters for filtering DE results, valid parameters are: '
+            '"min_in_group_fraction" (float), "max_out_group_fraction" (float), '
+            '"min_fold_change" (float).',
+        ),
+        click.option(
+            '--logreg-param',
+            type=Dictionary(),
+            default=None,
+            show_default=True,
+            help='Parameters passed to `sklearn.linear_model.LogisticRegression`.',
+        ),
+        click.option(
+            '--save',
+            type=click.Path(dir_okay=False, writable=True),
+            default=None,
+            show_default=True,
+            help='Tab-separated table to store results of differential expression '
+            'analysis.',
+        ),
+    ],
+
+    'paga': [
+        *COMMON_OPTIONS['input'],
+        *COMMON_OPTIONS['output'],
+        COMMON_OPTIONS['knn_graph'][0], # --use-graph
+        COMMON_OPTIONS['key_added'],
+        click.option(
+            '--groups',
+            type=click.STRING,
+            required=True,
+            help='Key for categorical in `.obs`. You can pass your predefined '
+            'groups by choosing any categorical annotation of observations.',
+        ),
+        click.option(
+            '--model',
+            type=click.Choice(['v1.2', 'v1.0']),
+            default='v1.2',
+            show_default=True,
+            help='The PAGA connectivity model.',
+        ),
+    ],
+
+    'diffmap': [
+        *COMMON_OPTIONS['input'],
+        *COMMON_OPTIONS['output'],
+        COMMON_OPTIONS['knn_graph'][0], # --use-graph
+        COMMON_OPTIONS['key_added'],
+        COMMON_OPTIONS['export_embedding'],
+        COMMON_OPTIONS['n_comps'],
+    ],
+
+    'dpt': [
+        *COMMON_OPTIONS['input'],
+        *COMMON_OPTIONS['output'],
+        COMMON_OPTIONS['knn_graph'][0], # --use-graph
+        COMMON_OPTIONS['key_added'],
+        click.option(
+            '--root',
+            type=(click.STRING, click.STRING),
+            default=(None, None),
+            show_default=True,
+            help='Specify a categorical annotaion of observations (`.obs`) and a '
+            'value representing the root cells.',
+        ),
+        click.option(
+            '--n-dcs',
+            type=click.INT,
+            default=10,
+            show_default=True,
+            help='The number of diffusion components to use.',
+        ),
+        click.option(
+            '--n-branchings',
+            type=click.INT,
+            default=0,
+            show_default=True,
+            help='Number of branchings to detect.',
+        ),
+        click.option(
+            '--min-group-size',
+            type=click.FLOAT,
+            default=0.01,
+            show_default=True,
+            help='During recursive splitting of branches for --n-branchings > 1, '
+            'do not consider branches/groups that contain fewer than this fraction '
+            'of the total number of data points.',
+        ),
+    ],
+
+    'embed': [
+        *COMMON_OPTIONS['input'],
+        *COMMON_OPTIONS['plot'],
+        *COMMON_OPTIONS['frame_title'],
+        click.option(
+            '--basis',
+            type=click.STRING,
+            default='umap',
+            show_default=True,
+            help='Name of the embedding to plot, must be a key of `.obsm` without '
+            'the prefix "X_".',
+        ),
+        click.option(
+            '--color',
+            type=CommaSeparatedText(simplify=True),
+            default=None,
+            show_default=True,
+            help='Keys for annotations of observations/cells or variables/genes.',
+        ),
+        click.option(
+            '--use-raw/--no-raw',
+            default=None,
+            show_default=True,
+            help='Use `.raw` attribute for coloring with gene expression. If '
+            '`None`, uses `.raw` if present.',
+        ),
+        click.option(
+            '--legend-loc',
+            type=click.Choice(['right margin', 'on data']),
+            default='right margin',
+            show_default=True,
+            help='Location of legend, either "on data", "right margin" or valid '
+            'keywords for `matplotlib.legend`.',
+        ),
+        click.option(
+            '--legend-fontsize',
+            type=click.INT,
+            default=15,
+            show_default=True,
+            help='Legend font size.',
+        ),
+        click.option(
+            '--size',
+            type=click.FLOAT,
+            default=None,
+            show_default=True,
+            help='Point size. Automatically computed if not specified.',
+        ),
+    ],
+
+    'plot_paga': [
+        *COMMON_OPTIONS['input'],
+        *COMMON_OPTIONS['plot'],
+        *COMMON_OPTIONS['frame_title'],
+        click.option(
+            '--use-key',
+            type=click.STRING,
+            default='paga',
+            show_default=True,
+            help='The key in `.uns` that contains trajectory information.',
+        ),
+        click.option(
+            '--layout',
+            type=click.Choice(['fa', 'fr', 'grid_fr', 'kk', 'lgl', 'drl', 'rt']),
+            default='fr',
+            show_default=True,
+            help='Plotting layout that computes positions.',
+        ),
+        click.option(
+            '--init-pos',
+            type=click.STRING,
+            default=None,
+            show_default=True,
+            help='Plotting layout that computes positions.',
+        ),
+        click.option(
+            '--threshold',
+            type=click.FLOAT,
+            default=0.01,
+            show_default=True,
+            help='Do not draw edges for weights below this threshold. Set to 0 to '
+            'include all edges.',
+        ),
+        click.option(
+            '--root',
+            type=click.INT,
+            default=0,
+            show_default=True,
+            help='If choosing a tree layout, this is the index of the root node.',
+        ),
+        click.option(
+            '--transitions',
+            type=click.STRING,
+            default=None,
+            show_default=True,
+            help='Key for `.uns["paga"]` that specifies the matrix, e.g. '
+            '`transition_confidence`, that stores the arrows.',
+        ),
+        click.option(
+            '--single-component',
+            is_flag=True,
+            default=False,
+            show_default=True,
+            help='Restrict to largest connected component',
+        ),
+        click.option(
+            '--solid-edges',
+            type=click.Choice(['connectivities', 'connectivities_tree']),
+            default='connectivities',
+            show_default=True,
+            help='Key for `.uns["paga"]` that specifies the matrix that stores the '
+            'edges to be drawn solid black.',
+        ),
+        click.option(
+            '--basis',
+            type=click.STRING,
+            default=None,
+            show_default=True,
+            help='Name of the embedding to plot, must be a key of `.obsm` without '
+            'the prefix "X_".',
+        ),
+        click.option(
+            '--color',
+            type=click.STRING,
+            default=None,
+            show_default=True,
+            help='Key for annotation of observations/cells or variables/genes.',
+        ),
+        click.option(
+            '--legend-loc',
+            type=click.Choice(['right margin', 'on data']),
+            default='right margin',
+            show_default=True,
+            help='Location of legend, either "on data", "right margin" or valid '
+            'keywords for `matplotlib.legend`.',
+        ),
+        click.option(
+            '--size',
+            type=click.FLOAT,
+            default=None,
+            show_default=True,
+            help='Point size. Automatically computed if not specified.',
+        ),
+        click.option(
+            '--node-size-scale',
+            type=click.FLOAT,
+            default=1.0,
+            show_default=True,
+            help='Increase of decrease the size of the nodes.',
+        ),
+        click.option(
+            '--fontsize',
+            type=click.INT,
+            default=None,
+            show_default=True,
+            help='Font size for node labels.',
+        ),
+        click.option(
+            '--edge-width-scale',
+            type=click.FLOAT,
+            default=1.0,
+            show_default=True,
+            help='Increase of decrease the width of the edges.',
+        ),
+        click.option(
+            '--arrowsize',
+            type=click.INT,
+            default=30,
+            show_default=True,
+            help='For directed graphs, specify the length and width of the arrowhead.',
+        ),
+    ],
+    
+    'sviol': [
+        *COMMON_OPTIONS['input'],
+        *COMMON_OPTIONS['plot'],
+        COMMON_OPTIONS['use_raw'],
+        COMMON_OPTIONS['var_names'],
+        *COMMON_OPTIONS['rank_genes_groups_plots'],
+        *COMMON_OPTIONS['diffexp_plot'],
+        *COMMON_OPTIONS['sviol'],
+        COMMON_OPTIONS['swap_axes'],
+    ],
+
+    'dot': [ 
+        *COMMON_OPTIONS['input'],
+        *COMMON_OPTIONS['plot'],
+        COMMON_OPTIONS['use_raw'],
+        COMMON_OPTIONS['var_names'],
+        *COMMON_OPTIONS['rank_genes_groups_plots'],
+        *COMMON_OPTIONS['diffexp_plot'],
+        *COMMON_OPTIONS['dot'],
+    ],
+    
+    'matrix': [
+        *COMMON_OPTIONS['input'],
+        *COMMON_OPTIONS['plot'],
+        COMMON_OPTIONS['use_raw'],
+        COMMON_OPTIONS['var_names'],
+        *COMMON_OPTIONS['rank_genes_groups_plots'],
+        *COMMON_OPTIONS['diffexp_plot'],
+    ],
+    
+    'heat': [
+        *COMMON_OPTIONS['input'],
+        *COMMON_OPTIONS['plot'],
+        COMMON_OPTIONS['use_raw'],
+        COMMON_OPTIONS['var_names'],
+        *COMMON_OPTIONS['rank_genes_groups_plots'],
+        *COMMON_OPTIONS['diffexp_plot'],
+        *COMMON_OPTIONS['heat'],
+        COMMON_OPTIONS['swap_axes'],
+    ],
+
+}

--- a/scanpy_scripts/cmds.py
+++ b/scanpy_scripts/cmds.py
@@ -10,34 +10,6 @@ from .cmd_utils import (
     make_subcmd,
     make_plot_function,
 )
-from .cmd_options import (
-    READ_CMD_OPTIONS,
-    FILTER_CMD_OPTIONS,
-    NORM_CMD_OPTIONS,
-    HVG_CMD_OPTIONS,
-    SCALE_CMD_OPTIONS,
-    REGRESS_CMD_OPTIONS,
-    PCA_CMD_OPTIONS,
-    NEIGHBOR_CMD_OPTIONS,
-    UMAP_CMD_OPTIONS,
-    TSNE_CMD_OPTIONS,
-    FDG_CMD_OPTIONS,
-    LOUVAIN_CMD_OPTIONS,
-    LEIDEN_CMD_OPTIONS,
-    DIFFEXP_CMD_OPTIONS,
-    PAGA_CMD_OPTIONS,
-    DIFFMAP_CMD_OPTIONS,
-    DPT_CMD_OPTIONS,
-    PLOT_EMBED_CMD_OPTIONS,
-    PLOT_PAGA_CMD_OPTIONS,
-    PLOT_STACKED_VIOLIN_CMD_OPTIONS,
-    PLOT_RANK_GENE_GROUPS_STACKED_VIOLIN_CMD_OPTIONS,
-    PLOT_DOT_CMD_OPTIONS,
-    PLOT_MATRIX_CMD_OPTIONS,
-    PLOT_RANK_GENE_GROUPS_MATRIX_CMD_OPTIONS,
-    PLOT_HEATMAP_CMD_OPTIONS,
-    PLOT_RANK_GENE_GROUPS_HEATMAP_CMD_OPTIONS,
-)
 from .lib._read import read_10x
 from .lib._filter import filter_anndata
 from .lib._norm import normalize
@@ -50,7 +22,7 @@ from .lib._fdg import fdg
 from .lib._louvain import louvain
 from .lib._leiden import leiden
 from .lib._diffexp import diffexp
-from .lib._paga import paga, plot_paga
+from .lib._paga import paga
 from .lib._diffmap import diffmap
 from .lib._dpt import dpt
 
@@ -73,7 +45,6 @@ _IP_DESC = '\n'.join([_I_DESC, _P_DESC])
 
 READ_CMD = make_subcmd(
     'read',
-    READ_CMD_OPTIONS,
     read_10x,
     cmd_desc='Read 10x data and save in specified format.',
     arg_desc=_O_DESC,
@@ -82,7 +53,6 @@ READ_CMD = make_subcmd(
 
 FILTER_CMD = make_subcmd(
     'filter',
-    FILTER_CMD_OPTIONS,
     filter_anndata,
     cmd_desc='Filter data based on specified conditions.',
     arg_desc=_IO_DESC,
@@ -91,7 +61,6 @@ FILTER_CMD = make_subcmd(
 
 NORM_CMD = make_subcmd(
     'norm',
-    NORM_CMD_OPTIONS,
     normalize,
     cmd_desc='Normalise data per cell.',
     arg_desc=_IO_DESC,
@@ -100,7 +69,6 @@ NORM_CMD = make_subcmd(
 
 HVG_CMD = make_subcmd(
     'hvg',
-    HVG_CMD_OPTIONS,
     hvg,
     cmd_desc='Find highly variable genes.',
     arg_desc=_IO_DESC,
@@ -109,7 +77,6 @@ HVG_CMD = make_subcmd(
 
 SCALE_CMD = make_subcmd(
     'scale',
-    SCALE_CMD_OPTIONS,
     sc.pp.scale,
     cmd_desc='Scale data per gene.',
     arg_desc=_IO_DESC,
@@ -118,7 +85,6 @@ SCALE_CMD = make_subcmd(
 
 REGRESS_CMD = make_subcmd(
     'regress',
-    REGRESS_CMD_OPTIONS,
     sc.pp.regress_out,
     cmd_desc='Regress-out observation variables.',
     arg_desc=_IO_DESC,
@@ -127,7 +93,6 @@ REGRESS_CMD = make_subcmd(
 
 PCA_CMD = make_subcmd(
     'pca',
-    PCA_CMD_OPTIONS,
     pca,
     cmd_desc='Dimensionality reduction by PCA.',
     arg_desc=_IO_DESC,
@@ -135,7 +100,6 @@ PCA_CMD = make_subcmd(
 
 NEIGHBOR_CMD = make_subcmd(
     'neighbor',
-    NEIGHBOR_CMD_OPTIONS,
     neighbors,
     cmd_desc='Compute a neighbourhood graph of observations.',
     arg_desc=_IO_DESC,
@@ -143,7 +107,6 @@ NEIGHBOR_CMD = make_subcmd(
 
 UMAP_CMD = make_subcmd(
     'umap',
-    UMAP_CMD_OPTIONS,
     umap,
     cmd_desc='Embed the neighborhood graph using UMAP.',
     arg_desc=_IO_DESC,
@@ -151,7 +114,6 @@ UMAP_CMD = make_subcmd(
 
 TSNE_CMD = make_subcmd(
     'tsne',
-    TSNE_CMD_OPTIONS,
     tsne,
     cmd_desc='Embed the cells using t-SNE.',
     arg_desc=_IO_DESC,
@@ -159,7 +121,6 @@ TSNE_CMD = make_subcmd(
 
 FDG_CMD = make_subcmd(
     'fdg',
-    FDG_CMD_OPTIONS,
     fdg,
     cmd_desc='Embed the neighborhood graph using force-directed graph.',
     arg_desc=_IO_DESC,
@@ -167,7 +128,6 @@ FDG_CMD = make_subcmd(
 
 DIFFMAP_CMD = make_subcmd(
     'diffmap',
-    DIFFMAP_CMD_OPTIONS,
     diffmap,
     cmd_desc='Embed the neighborhood graph using diffusion map.',
     arg_desc=_IO_DESC,
@@ -175,7 +135,6 @@ DIFFMAP_CMD = make_subcmd(
 
 LOUVAIN_CMD = make_subcmd(
     'louvain',
-    LOUVAIN_CMD_OPTIONS,
     louvain,
     cmd_desc='Find clusters by Louvain algorithm.',
     arg_desc=_IO_DESC,
@@ -183,7 +142,6 @@ LOUVAIN_CMD = make_subcmd(
 
 LEIDEN_CMD = make_subcmd(
     'leiden',
-    LEIDEN_CMD_OPTIONS,
     leiden,
     cmd_desc='Find clusters by Leiden algorithm.',
     arg_desc=_IO_DESC,
@@ -191,7 +149,6 @@ LEIDEN_CMD = make_subcmd(
 
 DIFFEXP_CMD = make_subcmd(
     'diffexp',
-    DIFFEXP_CMD_OPTIONS,
     diffexp,
     cmd_desc='Find markers for each clusters.',
     arg_desc=_IO_DESC,
@@ -199,7 +156,6 @@ DIFFEXP_CMD = make_subcmd(
 
 PAGA_CMD = make_subcmd(
     'paga',
-    PAGA_CMD_OPTIONS,
     paga,
     cmd_desc='Trajectory inference by abstract graph analysis.',
     arg_desc=_IO_DESC,
@@ -207,7 +163,6 @@ PAGA_CMD = make_subcmd(
 
 DPT_CMD = make_subcmd(
     'dpt',
-    DPT_CMD_OPTIONS,
     dpt,
     cmd_desc='Calculate diffusion pseudotime relative to the root cells.',
     arg_desc=_IO_DESC,
@@ -215,72 +170,43 @@ DPT_CMD = make_subcmd(
 
 PLOT_EMBED_CMD = make_subcmd(
     'embed',
-    PLOT_EMBED_CMD_OPTIONS,
-    make_plot_function(sc.plotting._tools.scatterplots.plot_scatter),
+    make_plot_function('scatter'),
     cmd_desc='Plot cell embeddings.',
     arg_desc=_IP_DESC,
 )
 
 PLOT_STACKED_VIOLIN_CMD = make_subcmd(
     'sviol',
-    PLOT_STACKED_VIOLIN_CMD_OPTIONS,
-    make_plot_function(sc.plotting._anndata.stacked_violin),
+    make_plot_function('sviol'),
     cmd_desc='Plot stacked violin plots.',
-    arg_desc=_IP_DESC,
-)
-
-PLOT_RANK_GENE_GROUPS_STACKED_VIOLIN_CMD = make_subcmd(
-    'rggsviol',
-    PLOT_RANK_GENE_GROUPS_STACKED_VIOLIN_CMD_OPTIONS,
-    make_plot_function(sc.plotting._tools.rank_genes_groups_stacked_violin, kind='stacked_violin'),
-    cmd_desc='Plot ranking of genes using stacked_violin plot.',
     arg_desc=_IP_DESC,
 )
 
 PLOT_DOT_CMD = make_subcmd(
     'dot',
-    PLOT_DOT_CMD_OPTIONS,
-    make_plot_function(sc.plotting._anndata.dotplot),
+    make_plot_function('dot'),
     cmd_desc='Plot a dot plot of expression values.',
     arg_desc=_IP_DESC,
 )
 
 PLOT_MATRIX_CMD = make_subcmd(
     'matrix',
-    PLOT_MATRIX_CMD_OPTIONS,
-    make_plot_function(sc.plotting._anndata.matrixplot),
+    make_plot_function('matrix'),
     cmd_desc='Plot a heatmap of the mean expression values per cluster.',
-    arg_desc=_IP_DESC,
-)
-
-PLOT_RANK_GENE_GROUPS_MATRIX_CMD = make_subcmd(
-    'rggmatrix',
-    PLOT_RANK_GENE_GROUPS_MATRIX_CMD_OPTIONS,
-    make_plot_function(sc.plotting._tools.rank_genes_groups_matrixplot, kind='matrixplot'),
-    cmd_desc='Plot ranking of genes using matrixplot plot.',
     arg_desc=_IP_DESC,
 )
 
 PLOT_HEATMAP_CMD = make_subcmd(
     'heat',
-    PLOT_HEATMAP_CMD_OPTIONS,
-    make_plot_function(sc.plotting._anndata.heatmap),
+    make_plot_function('heat'),
     cmd_desc='Plot a heatmap of the expression values of genes.',
-    arg_desc=_IP_DESC,
-)
-
-PLOT_RANK_GENE_GROUPS_HEATMAP_CMD = make_subcmd(
-    'rggheat',
-    PLOT_RANK_GENE_GROUPS_HEATMAP_CMD_OPTIONS,
-    make_plot_function(sc.plotting._tools.rank_genes_groups_heatmap, kind='heatmap'),
-    cmd_desc='Plot a ranking of genes using heatmap plot.',
     arg_desc=_IP_DESC,
 )
 
 PLOT_PAGA_CMD = make_subcmd(
     'paga',
-    PLOT_PAGA_CMD_OPTIONS,
-    make_plot_function(plot_paga, kind='paga'),
+    make_plot_function('plot_paga', kind='paga'),
     cmd_desc='Plot PAGA trajectories.',
     arg_desc=_IP_DESC,
+    opt_set='plot_paga'
 )

--- a/scanpy_scripts/lib/_dpt.py
+++ b/scanpy_scripts/lib/_dpt.py
@@ -4,7 +4,7 @@ scanpy dpt
 
 import numpy as np
 import scanpy as sc
-from ..cmd_utils import (
+from ..obj_utils import (
     _set_default_key,
     _restore_default_key,
     _backup_default_key,

--- a/scanpy_scripts/lib/_neighbors.py
+++ b/scanpy_scripts/lib/_neighbors.py
@@ -3,7 +3,7 @@ scanpy neighbors
 """
 
 import scanpy as sc
-from ..cmd_utils import (
+from ..obj_utils import (
     _backup_default_key,
     _delete_backup_key,
     _rename_default_key,

--- a/scanpy_scripts/lib/_paga.py
+++ b/scanpy_scripts/lib/_paga.py
@@ -4,7 +4,7 @@ scanpy paga
 
 import numpy as np
 import scanpy as sc
-from ..cmd_utils import (
+from ..obj_utils import (
     _backup_default_key,
     _delete_backup_key,
     _rename_default_key,

--- a/scanpy_scripts/obj_utils.py
+++ b/scanpy_scripts/obj_utils.py
@@ -1,0 +1,103 @@
+"""
+Provide helper functions for constructing sub-commands
+"""
+
+import scanpy as sc
+
+# The functions below handles slot key.
+#
+# Default keys are those read and written by scanpy functions by default, e.g
+# "X_pca", "neighbors", "louvain", etc.
+#
+# Of them, `obsm_key` specifically refers to those used for embedding, e.g
+# "X_pca", "X_tsne", "X_umap", etc.
+#
+# The approach for supplying a non-standard key to a function as input is:
+# if the function only reads the value in the default key, we first backup the
+# value in the default key, then write the value of the non-standard key into
+# the standard key, run the funtion, and finally restore the value of the
+# default key from backup and delete the backup.
+#
+# The approach for writting the results of a function to a non-standard key is:
+# if the function only writes to the default key, we first backup the value in
+# the default key, run the function, copy the value of the default key to the
+# desired non-standard key, and finally restore the value of the default key
+# from backup and delete the backup.
+#
+# Specical treatment for obsm_key is needed, as the underlying data type is not
+# a python dictionary but a numpy array.
+
+def _backup_default_key(slot, default):
+    if default in slot.keys():
+        bkup_key = f'{default}_bkup'
+        if bkup_key in slot.keys():
+            sc.logging.warn(f'overwrite existing {bkup_key}')
+        slot[bkup_key] = slot[default]
+
+
+def _restore_default_key(slot, default, key=None):
+    if key != default:
+        bkup_key = f'{default}_bkup'
+        if bkup_key in slot.keys():
+            slot[default] = slot[bkup_key]
+            del slot[bkup_key]
+
+
+def _delete_backup_key(slot, default):
+    bkup_key = f'{default}_bkup'
+    if bkup_key in slot.keys():
+        del slot[bkup_key]
+
+
+def _set_default_key(slot, default, key):
+    if key != default:
+        if key not in slot.keys():
+            raise KeyError(f'{key} does not exist')
+        _backup_default_key(slot, default)
+        slot[default] = slot[key]
+
+
+def _rename_default_key(slot, default, key):
+    if not default in slot.keys():
+        raise KeyError(f'{default} does not exist')
+    slot[key] = slot[default]
+    del slot[default]
+    _restore_default_key(slot, default)
+
+
+def _backup_obsm_key(adata, key):
+    if key in adata.obsm_keys():
+        bkup_key = f'{key}_bkup'
+        if bkup_key in adata.obsm_keys():
+            sc.logging.warn(f'overwrite existing {bkup_key}')
+        adata.obsm[bkup_key] = adata.obsm[key]
+
+
+def _restore_obsm_key(adata, key, new_key=None):
+    if new_key != key:
+        bkup_key = f'{key}_bkup'
+        if bkup_key in adata.obsm_keys():
+            adata.obsm[key] = adata.obsm[bkup_key]
+            del adata.obsm[bkup_key]
+
+
+def _delete_obsm_backup_key(adata, key):
+    bkup_key = f'{key}_bkup'
+    if bkup_key in adata.obsm_keys():
+        del adata.obsm[bkup_key]
+
+
+def _set_obsm_key(adata, key, new_key):
+    if new_key != key:
+        if new_key not in adata.obsm_keys():
+            raise KeyError(f'{new_key} does not exist')
+        _backup_obsm_key(adata, key)
+        adata.obsm[key] = adata.obsm[new_key]
+
+
+def _rename_obsm_key(adata, from_key, to_key):
+    if not from_key in adata.obsm_keys():
+        raise KeyError(f'{from_key} does not exist')
+    adata.obsm[to_key] = adata.obsm[from_key]
+    del adata.obsm[from_key]
+    _restore_obsm_key(adata, from_key)


### PR DESCRIPTION
So, @nh3 , this PR is an attempt to fulfil what I promised you yesterday, namely to make the rank_genes_groups_* variants of the D/E plots a parameter rather than a separate command. This got a bit more complicated than I'd hoped, you may have a simpler solution.

So the main change:

- A single parameter list for e.g. stacked violins, matrix plots etc, with optional parameters applying to the RGG/ non-RGG variants (indicated by a flag)
- Function selection by make_plot_function() made dynamic and responsive to --rgg, to select the RGG/ non-RGG variant as appropriate.

I also turned the various command option lists into a single keyed hash for ease of use- hope you don't mind. A knock-on is that I needed to move the various slot methods to a different file to avoid circular imports. 

In the dynamic function selection between RGG/ non-RGG variants I found it necessary to exclude any options not used in the downstream functions. e.g. var_names passed internally by the RGG variants, so you have to exclude it before calling that function. This has let to some nastiness in make_plot_function() where I unset any options not used in the target function. That's hard-coded because I couldn't see a better way.

If you can see a way of making these changes more elegant, I'd be most appreciative!