### PR TITLE
[WIP] Proposal to move certain observations generation to read step

### DIFF
--- a/scanpy_scripts/lib/_read.py
+++ b/scanpy_scripts/lib/_read.py
@@ -46,7 +46,7 @@ def read_10x(
         )
 
     gene_name = 'index'
-    if var_names == 'gene_ids'
+    if var_names == 'gene_ids':
         gene_name = 'gene_symbols'
         
     qc_vars = list()

--- a/scanpy_scripts/lib/_read.py
+++ b/scanpy_scripts/lib/_read.py
@@ -62,8 +62,8 @@ def read_10x(
                 if k_cat.sum() > 0:
                     adata.var[var_cat] = k_cat
                     qc_vars.append(var_cat)
-            else:
-                logging.warning('No {} genes found, skip calculating expression of {} genes'.format(starts_with, var_cat))
+                else:
+                    logging.warning('No {} genes found, skip calculating expression of {} genes'.format(starts_with, var_cat))
             except AttributeError:
                 logging.warning(
                     'Specified gene column [%s] not found, skip calculating '

--- a/scanpy_scripts/lib/_read.py
+++ b/scanpy_scripts/lib/_read.py
@@ -45,6 +45,8 @@ def read_10x(
         )
 
     gene_name = 'index'
+    if var_names == 'gene_ids'
+        gene_name = 'gene_symbols'
     try:
         gene_names = getattr(adata.var, gene_name)
         k_mito = gene_names.str.startswith('MT-')


### PR DESCRIPTION
Currently to be able to use 'n_counts', 'n_genes', etc and so on, one needs to go through the filtering step. I think it would make more sense, specially to be able to do QC right after reading, to enable the same parts that generate those observations in the filtering step to be present in the reading step (not sure where you are putting the common code calls @nh3 to avoid duplication, but it you let me know, I can put the repeated code there).

I intend to add as well to the read step an option for the prefix of the spikes, so that and percentage obs can be calculated as well for those. Those things would complete the functionality for Chichau's QC part for the course (besides some plots we would need to add).