### PR TITLE
Feature/filtering tweaks

### DIFF
--- a/scanpy_scripts/cmd_options.py
+++ b/scanpy_scripts/cmd_options.py
@@ -534,6 +534,13 @@ CMD_OPTIONS = {
             'Multiple -p entries allowed.',
         ),
         click.option(
+            '--boolean', '-b',
+            type=(click.STRING),
+            multiple=True,
+            help='A boolean variable to filter by. Multiple -b entries '
+            'allowed.'
+        ),
+        click.option(
             '--category', '-c',
             type=(click.STRING, CommaSeparatedText()),
             multiple=True,

--- a/scanpy_scripts/lib/_filter.py
+++ b/scanpy_scripts/lib/_filter.py
@@ -254,7 +254,7 @@ def _get_filter_conditions(attributes, param, category, subset, boolean):
         found, cond_cat, cond_name = _attributes_exists(
             name, attributes, 'bool')
         if found > 1:
-            raise click.ClickException(f"Ambiguous attribute \"{name}\" found in "
+            raise click.ClickException(f"Ambiguous boolean \"{name}\" found in "
                                        "both cell and gene table")
         if found < 1:
             raise click.ClickException(f"Boolean \"{name}\" unavailable")

--- a/scanpy_scripts/lib/_filter.py
+++ b/scanpy_scripts/lib/_filter.py
@@ -141,7 +141,7 @@ def _get_attributes(adata):
             if dtype.name == 'category' and dtype.categories.is_boolean():
                 attributes['c']['bool'].append(attr)
             attributes['c']['categorical'].append(attr)
-        elif typ in ('i', 'f'):
+        elif typ in ('i', 'f', 'u'):
             attributes['c']['numerical'].append(attr)
         elif typ == 'b':
             attributes['c']['bool'].append(attr)
@@ -152,7 +152,7 @@ def _get_attributes(adata):
             if dtype.name == 'category' and dtype.categories.is_boolean():
                 attributes['g']['bool'].append(attr)
             attributes['g']['categorical'].append(attr)
-        elif typ in ('i', 'f'):
+        elif typ in ('i', 'f', 'u'):
             attributes['g']['numerical'].append(attr)
         elif typ == 'b':
             attributes['g']['bool'].append(attr)

--- a/scanpy_scripts/lib/_filter.py
+++ b/scanpy_scripts/lib/_filter.py
@@ -91,7 +91,11 @@ def filter_anndata(
     for cond in conditions['g']['categorical']:
         name, values = cond
         attr = getattr(adata.var, name)
-        k_gene = k_gene & attr.isin(values)
+        if values[0].startswith('!'):
+            values[0] = values[0][1:]
+            k_gene = k_gene & (~attr.isin(values))
+        else:
+            k_gene = k_gene & attr.isin(values)
 
     adata._inplace_subset_obs(k_cell)
     adata._inplace_subset_var(k_gene)
@@ -195,8 +199,8 @@ def _get_filter_conditions(attributes, param, category, subset):
         pt_match = percent_top_pattern.match(cond_name)
         qv_match = qc_vars_pattern.match(cond_name)
         if found > 1:
-            raise click.ClickException(f'Ambiguous parameter "{name}" found in '
-                                       'both cell and gene table')
+            raise click.ClickException(f"Ambiguous parameter \"{name}\" found in "
+                                       "both cell and gene table")
         if found < 1:
             if pt_match:
                 pct_top.append(int(pt_match['n']))
@@ -205,7 +209,7 @@ def _get_filter_conditions(attributes, param, category, subset):
                 qc_vars.append(qv_match['qc_var'])
                 cond_cat = 'c'
             else:
-                raise click.ClickException(f'Parameter "{name}" unavailable')
+                raise click.ClickException(f"Parameter \"{name}\" unavailable")
         if pt_match or qv_match:
             vmin *= 100
             vmax *= 100
@@ -215,10 +219,10 @@ def _get_filter_conditions(attributes, param, category, subset):
         found, cond_cat, cond_name = _attributes_exists(
             name, attributes, 'categorical')
         if found > 1:
-            raise click.ClickException(f'Ambiguous attribute "{name}" found in '
-                                       'both cell and gene table')
+            raise click.ClickException(f"Ambiguous attribute \"{name}\" found in "
+                                       "both cell and gene table")
         if found < 1:
-            raise click.ClickException('Attribute "{name}" unavailable')
+            raise click.ClickException("Attribute \"{name}\" unavailable")
         if not isinstance(values, (list, tuple)):
             fh = values
             values = fh.read().rstrip().split('\n')


### PR DESCRIPTION
This PR makes the following fixes and extensions to the negative filtering devised by @nh3 in https://github.com/ebi-gene-expression-group/scanpy-scripts/pull/68:

- Negative filtering extended to genes (only previously applied to cells)
- Format strings with errors corrected (doesn't work with single quotes)
- Boolean variables (e.g. 'mito') included with negation (required tweaks to  _attributes_exists()). I was confused as to why I couldn't use 'mito' as a categorical variable. 
- Allowed for 'unsigned integer' (u) as a numeric type. For the later parts of the test workflow in the .bats file, the boolean variables become unsigned ints (haven't dug into why), and failure to recognise them means you can't filter by e.g. mito at that stage. Maybe we should prevent the booleans being transformed in that way, but uints shouldn't be ignored in any case. 

I note that to actually use the negative filtering it's necessary to enclose the options with single quotes like:

```
scanpy-cli filter --category c:FOO '!bar' --input-format 'anndata' input.h5ad   --show-obj stdout --output-format 'anndata' output.h5ad
```

Failure to do so (either by not quoting, or by using double quotes) results in errors like:

```
-bash: !six: event not found
```

 Something we may need to document, or else change the leading character we use.