### PR TITLE
Allow filtering of boolean variables as categorical

### DIFF
--- a/scanpy_scripts/lib/_filter.py
+++ b/scanpy_scripts/lib/_filter.py
@@ -133,6 +133,7 @@ def _get_attributes(adata):
             attributes['c']['numerical'].append(attr)
         elif typ == 'b':
             attributes['c']['bool'].append(attr)
+            attributes['c']['categorical'].append(attr)
 
     for attr, dtype in adata.var.dtypes.to_dict().items():
         typ = dtype.kind
@@ -144,6 +145,7 @@ def _get_attributes(adata):
             attributes['g']['numerical'].append(attr)
         elif typ == 'b':
             attributes['g']['bool'].append(attr)
+            attributes['g']['categorical'].append(attr)
 
     attributes['c']['numerical'].extend([
         'n_genes',


### PR DESCRIPTION
This PR addresses an issue that got lost between the rejected https://github.com/ebi-gene-expression-group/scanpy-scripts/pull/69 and https://github.com/ebi-gene-expression-group/scanpy-scripts/pull/70. Namely: we want to be able to filter on boolean variables, but @nh3 felt that additional UI elements for boolean-specific filters were unnecessary. 

The change here is just to add booleans to the lists of categorical variables, as well as the booleans. This way pct_* can still work with the booleans, but filters supplied as categorical will still work with boolean variables. I've check and this works with the test cases I have. 