### PR TITLE
Feature/fix svg defaults

### DIFF
--- a/scanpy_scripts/cmd_options.py
+++ b/scanpy_scripts/cmd_options.py
@@ -628,7 +628,7 @@ CMD_OPTIONS = {
         click.option(
             '--n-top-genes', '-t',
             type=click.INT,
-            default=2000,
+            default=None,
             show_default=True,
             help='Number of highly-variable genes to keep.',
         ),

--- a/scanpy_scripts/lib/_hvg.py
+++ b/scanpy_scripts/lib/_hvg.py
@@ -20,7 +20,7 @@ def hvg(
 
     # Check for n_top_genes beeing greater than the total genes
 
-    if 'n_top_genes' in kwargs:
+    if 'n_top_genes' in kwargs and kwargs['n_top_genes'] is not None:
         kwargs['n_top_genes'] = min(adata.n_vars, kwargs['n_top_genes'])
 
     if by_batch and isinstance(by_batch, (list, tuple)) and by_batch[0]:

--- a/scanpy_scripts/lib/_hvg.py
+++ b/scanpy_scripts/lib/_hvg.py
@@ -17,6 +17,12 @@ def hvg(
     Wrapper function for sc.highly_variable_genes(), mainly to support searching
     by batch and pooling.
     """
+
+    # Check for n_top_genes beeing greater than the total genes
+
+    if 'n_top_genes' in kwargs:
+        kwargs['n_top_genes'] = min(adata.n_vars, kwargs['n_top_genes'])
+
     if by_batch and isinstance(by_batch, (list, tuple)) and by_batch[0]:
         batch_name = by_batch[0]
         min_n = by_batch[1]


### PR DESCRIPTION
Current behaviour in scanpy-scripts has, I think (correct me if I'm wrong @nh3 ) been disabling 'Seurat' mode for detecting highly variable genes when calling pp.highly_variable_genes(). The following two changes address this:

1. Set n_top_genes default to 'None'. Previously, this would be set to 2000 when not specified (as it should not be for Seurat mode), overriding the method. So calling Seurat method from CLI impossible?
2. Where input matrix has fewer genes than n_top_genes, there is a scanpy error. So make sure the value is no greater than the maximum gene number.