### PR TITLE
Bump n_comps down to match low cell numbers

### DIFF
--- a/scanpy_scripts/lib/_pca.py
+++ b/scanpy_scripts/lib/_pca.py
@@ -2,6 +2,7 @@
 scanpy pca
 """
 
+import logging
 import scanpy as sc
 from ..obj_utils import write_embedding
 
@@ -9,6 +10,16 @@ def pca(adata, key_added=None, export_embedding=None, **kwargs):
     """
     Wrapper function for sc.pp.pca, for supporting named slot
     """
+
+    # n_comps may be greater than the number of cells (n_obs), which will
+    # produce an error. Additional logic may be required in future for very
+    # small gene numbers (adata.n_vars).
+    
+    if 'n_comps' in kwargs and kwargs['n_comps'] is not None:
+        if kwargs['n_comps'] > adata.n_obs:
+            logging.warning('n_comps exceeds cell number, resetting to %d', adata.n_obs)
+            kwargs['n_comps'] = adata.n_obs
+
     # omit "svd_solver" to let scanpy choose automatically
     if 'svd_solver' in kwargs and kwargs['svd_solver'] == 'auto':
         del kwargs['svd_solver']


### PR DESCRIPTION
Addressing https://github.com/ebi-gene-expression-group/scanpy-scripts/issues/77, reduce a supplied n_comps to match low cell numbers. Also supply a warning so we're not doing this silently.

Logic for low gene numbers to be added in future (see https://github.com/ebi-gene-expression-group/scanpy-scripts/pull/76), once seemingly more complex logic required there is resolved.