### PR TITLE
Hide singlet cell groups before marker detection

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,7 @@ install:
 script: ./scanpy-scripts-tests.bats
 
 cache:
-  pip: false
+  pip: true
   directories:
     - post_install_tests
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,7 @@ install:
 script: ./scanpy-scripts-tests.bats
 
 cache:
-  pip: true
+  pip: false
   directories:
     - post_install_tests
 

--- a/scanpy-scripts-tests.bats
+++ b/scanpy-scripts-tests.bats
@@ -116,7 +116,7 @@ setup() {
         skip "$singlet_obs exists"
     fi
 
-    run rm -rf $singlet_obs && eval "echo -e \"index\tgroupby_with_singlet\" > $singlet_obs && head -n 1 $data_dir/barcodes.tsv | while read -r b; do echo -e \"\$b\tcluster1\"; done >> $singlet_obs && sed -n '2,100p;101q' $data_dir/barcodes.tsv | awk -v cluster='cluster3' '{print \$1\"\t\"cluster}' >> $singlet_obs && tail -n +101 $data_dir/barcodes.tsv | while read -r b; do echo -e \"\$b\tcluster2\"; done >> $singlet_obs"
+    run rm -rf $singlet_obs && eval "echo -e \"index\tgroupby_with_singlet\" > $singlet_obs && head -n 1 $data_dir/barcodes.tsv | awk -v cluster='cluster1' '{print \$1\"\t\"cluster}' >> $singlet_obs && sed -n '2,100p;101q' $data_dir/barcodes.tsv | awk -v cluster='cluster3' '{print \$1\"\t\"cluster}' >> $singlet_obs && tail -n +101 $data_dir/barcodes.tsv | awk -v cluster='cluster2' '{print \$1\"\t\"cluster}' >> $singlet_obs"
 
     [ "$status" -eq 0 ]
     [ -f "$singlet_obs" ]

--- a/scanpy_scripts/lib/_diffexp.py
+++ b/scanpy_scripts/lib/_diffexp.py
@@ -41,6 +41,7 @@ def diffexp(
     saved_groups = adata.obs[groupby].copy()
     groups_counts = adata.obs[groupby].value_counts()
     adata.obs[groupby][saved_groups.isin(groups_counts.index[groups_counts < 2])] = None
+    adata.obs[groupby].cat.remove_unused_categories(inplace=True)
 
     sc.tl.rank_genes_groups(
         adata, use_raw=use_raw, n_genes=n_genes, key_added=diff_key, groupby=groupby, **kwargs)

--- a/scanpy_scripts/lib/_diffexp.py
+++ b/scanpy_scripts/lib/_diffexp.py
@@ -39,11 +39,11 @@ def diffexp(
     # https://github.com/theislab/scanpy/pull/1490
     
     saved_groups = adata.obs[groupby].copy()
-    groups_counts = adata.obs[key].value_counts()
+    groups_counts = adata.obs[groupby].value_counts()
     adata.obs[groupby][[ item in groups_counts.index[groups_counts < 2] for item in list(saved_groups) ]] = None
 
     sc.tl.rank_genes_groups(
-        adata, use_raw=use_raw, n_genes=n_genes, key_added=diff_key, **kwargs)
+        adata, use_raw=use_raw, n_genes=n_genes, key_added=diff_key, groupby=groupby, **kwargs)
 
     de_tbl = extract_de_table(adata.uns[diff_key])
 

--- a/scanpy_scripts/lib/_diffexp.py
+++ b/scanpy_scripts/lib/_diffexp.py
@@ -47,7 +47,7 @@ def diffexp(
             .index
         )
 
-        if len(groups) < len(adata.obs[groupby].cat.categories):
+        if len(groups_to_test) < len(adata.obs[groupby].cat.categories):
             groups = groups_to_test
             logging.warning('Singlet groups removed before passing to rank_genes_groups()')
 

--- a/scanpy_scripts/lib/_diffexp.py
+++ b/scanpy_scripts/lib/_diffexp.py
@@ -40,7 +40,7 @@ def diffexp(
     
     saved_groups = adata.obs[groupby].copy()
     groups_counts = adata.obs[groupby].value_counts()
-    adata.obs[groupby][[ item in groups_counts.index[groups_counts < 2] for item in list(saved_groups) ]] = None
+    adata.obs[groupby][saved_groups.isin(groups_counts.index[groups_counts < 2])] = None
 
     sc.tl.rank_genes_groups(
         adata, use_raw=use_raw, n_genes=n_genes, key_added=diff_key, groupby=groupby, **kwargs)

--- a/setup.py
+++ b/setup.py
@@ -40,7 +40,7 @@ setup(
         'scipy',
         'matplotlib',
         'pandas',
-        'h5py<3.1.0',
+        'h5py<3.0.0',
         'scanpy>=1.6.0',
         'louvain',
         'leidenalg',

--- a/setup.py
+++ b/setup.py
@@ -40,7 +40,7 @@ setup(
         'scipy',
         'matplotlib',
         'pandas',
-        'h5py',
+        'h5py<3.1.0',
         'scanpy>=1.6.0',
         'louvain',
         'leidenalg',


### PR DESCRIPTION
This PR addresses an issue whereby single clusters lead to division by 0 errors. I've suggested a fix in the Scanpy codebase (see https://github.com/theislab/scanpy/pull/1490), but we need this before we're likely to have a new Scanpy release, so I'm proposing an analagous fix here, whereby singlet clusters are hidden before rank_gene_groups() is run. 

Edit: I've also had to pin back h5py. Versions >= 3.0.0 cause errors like:

```
 ✗ Filter cells and genes from a raw object
   (in test file scanpy-scripts-tests.bats, line 126)
     `run rm -f $filter_obj && eval "$scanpy filter $filter_opt $read_obj $filter_obj"' failed
   Traceback (most recent call last):
     File "/Users/jmanning/miniconda3/envs/scanpy-scripts-test/bin/scanpy-cli", line 10, in <module>
       sys.exit(cli())
     File "/path/to/click/core.py", line 829, in __call__
       return self.main(*args, **kwargs)
     File "/path/to/click/core.py", line 782, in main
       rv = self.invoke(ctx)
     File "/path/to/click/core.py", line 1259, in invoke
       return _process_result(sub_ctx.command.invoke(sub_ctx))
     File "/path/to/click/core.py", line 1066, in invoke
       return ctx.invoke(self.callback, **ctx.params)
     File "/path/to/click/core.py", line 610, in invoke
       return callback(*args, **kwargs)
     File "/path/to/scanpy_scripts/cmd_utils.py", line 43, in cmd
       func(adata, **kwargs)
     File "/path/to/scanpy_scripts/lib/_filter.py", line 37, in filter_anndata
       k_mito = gene_names.str.startswith('MT-')
     File "/path/to/pandas/core/strings.py", line 2000, in wrapper
       raise TypeError(msg)
   TypeError: Cannot use .str.startswith with values of inferred dtype 'bytes'.
```

... because of the way .var is read from the HDF5 with strings becoming bytestrings. We'll eventually need to update usages like https://github.com/ebi-gene-expression-group/scanpy-scripts/blob/398bd0e1704566ae4ced978f3f5e2ced1f5e948a/scanpy_scripts/lib/_filter.py#L37, but for now let's just pin back h5py.