### PR TITLE
Remove CLI-level n_pcs hack and allow fallback to Scanpy's

### DIFF
--- a/scanpy_scripts/cmd_options.py
+++ b/scanpy_scripts/cmd_options.py
@@ -192,7 +192,7 @@ COMMON_OPTIONS = {
     'n_comps': click.option(
         '--n-comps',
         type=click.INT,
-        default=50,
+        default=None,
         show_default=True,
         help='Number of components to compute',
     ),

--- a/scanpy_scripts/lib/_pca.py
+++ b/scanpy_scripts/lib/_pca.py
@@ -11,15 +11,6 @@ def pca(adata, key_added=None, export_embedding=None, **kwargs):
     Wrapper function for sc.pp.pca, for supporting named slot
     """
 
-    # n_comps may be greater than the number of cells (n_obs), which will
-    # produce an error. Additional logic may be required in future for very
-    # small gene numbers (adata.n_vars).
-    
-    if 'n_comps' in kwargs and kwargs['n_comps'] is not None:
-        if kwargs['n_comps'] > adata.n_obs:
-            logging.warning('n_comps exceeds cell number, resetting to %d', adata.n_obs)
-            kwargs['n_comps'] = adata.n_obs
-
     # omit "svd_solver" to let scanpy choose automatically
     if 'svd_solver' in kwargs and kwargs['svd_solver'] == 'auto':
         del kwargs['svd_solver']


### PR DESCRIPTION
This PR was prompted because a previous PCA hack (mine I think) at https://github.com/ebi-gene-expression-group/scanpy-scripts/blob/20b526355b0125b01062dbcad79e07e84a5db0f3/scanpy_scripts/lib/_pca.py#L18 stopped working with newer Scanpy (or maybe it's dependencies)- it would now need to be `(adata.n_obs - 1)`. But actually I think it would be better to allow triggering of Scanpy's fallback here: https://github.com/theislab/scanpy/blob/6316d33640c44c9f9f92b655bbc601b54c126937/scanpy/preprocessing/_pca.py#L145, which we can only do by allowing non-specification of the n_pcs parameter.