### PR TITLE
Add pushes to CI, limited to tags starting with 'v', for releasing

### DIFF
--- a/.github/workflows/python-package-release.yml
+++ b/.github/workflows/python-package-release.yml
@@ -1,0 +1,34 @@
+name: Python package
+
+on: 
+    push:
+        tags:
+            - v*
+
+jobs:
+  build:
+
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v2
+    
+    - name: Set up Python 3
+      uses: actions/setup-python@v2
+      with:
+        python-version: '3.x'
+    
+    - name: Install dependencies
+      run: |
+        pip install -U setuptools>=40.1
+
+    - name: Build dists
+      run: |
+        pip install wheel
+        python setup.py sdist bdist_wheel
+    
+    - name: Publish to PyPI
+      uses: pypa/gh-action-pypi-publish@master
+      with:
+        user: __token__
+        password: ${{ secrets.pypi_password }}    

--- a/.github/workflows/python-package-release.yml
+++ b/.github/workflows/python-package-release.yml
@@ -1,4 +1,4 @@
-name: Python package
+name: Python package release
 
 on: 
     push:

--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -1,10 +1,6 @@
 name: Python package
 
-on: 
-    pull_request:
-    push:
-        tags:
-            - v*
+on: [pull_request]
 
 jobs:
   build:
@@ -36,15 +32,3 @@ jobs:
       run: |
         ./scanpy-scripts-tests.bats
  
-    - name: Build dists
-      if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags')
-      run: |
-        pip install wheel
-        python setup.py sdist bdist_wheel
-    
-    - name: Publish to PyPI
-      if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags')
-      uses: pypa/gh-action-pypi-publish@master
-      with:
-        user: __token__
-        password: ${{ secrets.pypi_password }}

--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -1,6 +1,10 @@
 name: Python package
 
-on: [pull_request]
+on: 
+    pull_request:
+    push:
+        tags:
+            - v*
 
 jobs:
   build:


### PR DESCRIPTION
Tiny fix- we need to run the workflow on pushes as well as pull requests, for release tags only. 