### PR TITLE
Allow annData output from plotting functions. 

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -25,7 +25,7 @@ jobs:
     
     - name: Install dependencies
       run: |
-        pip install -U setuptools>=40.1
+        pip install -U setuptools>=40.1 wheel
         pip install .
     
     - name: Test with bats

--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -25,7 +25,7 @@ jobs:
     
     - name: Install dependencies
       run: |
-        pip install -U setuptools>=40.1 wheel
+        pip install -U setuptools>=40.1 wheel cmake
         pip install .
     
     - name: Test with bats

--- a/scanpy_scripts/cmd_options.py
+++ b/scanpy_scripts/cmd_options.py
@@ -522,6 +522,15 @@ COMMON_OPTIONS = {
     ),
 }
 
+COMMON_OPTIONS['opt_output'] = [
+    click.option(
+        '--output-obj',
+        type=click.Path(dir_okay=False, writable=True),
+        help='Optionally output an object to the specified path.',
+    ),
+    *COMMON_OPTIONS['output'][1:], 
+]
+
 CMD_OPTIONS = {
     'read': [
         click.option(
@@ -1842,6 +1851,7 @@ CMD_OPTIONS = {
             show_default=True,
             help='For directed graphs, specify the length and width of the arrowhead.',
         ),
+        *COMMON_OPTIONS['opt_output'],
     ],
 
     'sviol': [

--- a/scanpy_scripts/lib/_paga.py
+++ b/scanpy_scripts/lib/_paga.py
@@ -100,3 +100,5 @@ def plot_paga(
             )
         finally:
             _restore_default_key(adata.uns, 'paga', use_key)
+
+    return adata


### PR DESCRIPTION
(related to https://github.com/ebi-gene-expression-group/container-galaxy-sc-tertiary/pull/224)

This PR addresses an issue with PAGA initialisation of FDG layouts. This requires .uns['paga']['pos'] to be set, which happens in sc.pl.paga() rather than sc.tl.paga(). Since the CLI currently only outputs the plot file from the PAGA plotting, we can't generate an object with the correct slots populated to run FDG with PAGA initialisation. 

My solution is just to allow an optional object output from the plotting functions. I've only enabled it for PAGA, but it could be used in future with other plotting functions that change the object content. I've also rearranged the tests to demonstrate the PAGA -> FDG.

The alternate solution would have been to change the PAGA wrapper to run sc.pl.paga and populate the 'pos' slot, but the above solution is neater I think.

Edit: also a couple of tweaks to the build env to keep Multicore t-sne happy.