### PR TITLE
Unpin loompy

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -25,7 +25,7 @@ jobs:
     
     - name: Install dependencies
       run: |
-        pip install -U setuptools>=40.1 wheel cmake<3.20
+        pip install -U setuptools>=40.1 wheel 'cmake<3.20'
         pip install .
     
     - name: Test with bats

--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -25,7 +25,7 @@ jobs:
     
     - name: Install dependencies
       run: |
-        pip install -U setuptools>=40.1 wheel cmake
+        pip install -U setuptools>=40.1 wheel cmake<3.20
         pip install .
     
     - name: Test with bats

--- a/scanpy_scripts/cmd_options.py
+++ b/scanpy_scripts/cmd_options.py
@@ -1613,7 +1613,7 @@ CMD_OPTIONS = {
             'each cell. Set to 0 to skip.'
         ),
         click.option(
-            '--n-trees',
+            '--annoy-n-trees',
             type=click.INT,
             default=10,
             show_default=True,

--- a/scanpy_scripts/cmd_options.py
+++ b/scanpy_scripts/cmd_options.py
@@ -1613,7 +1613,7 @@ CMD_OPTIONS = {
             'each cell. Set to 0 to skip.'
         ),
         click.option(
-            '--annoy-n-trees',
+            '--n-trees',
             type=click.INT,
             default=10,
             show_default=True,

--- a/setup.py
+++ b/setup.py
@@ -45,6 +45,7 @@ setup(
         'louvain',
         'leidenalg',
         'MulticoreTSNE',
+        'cmake<3.20',
         'Click',
         'umap-learn<0.4.0',
         'harmonypy>=0.0.5',

--- a/setup.py
+++ b/setup.py
@@ -45,7 +45,6 @@ setup(
         'louvain',
         'leidenalg',
         'MulticoreTSNE',
-        'cmake<3.20',
         'Click',
         'umap-learn<0.4.0',
         'harmonypy>=0.0.5',

--- a/setup.py
+++ b/setup.py
@@ -44,7 +44,6 @@ setup(
         'scanpy>=1.6.0',
         'louvain',
         'leidenalg',
-        'loompy>=2.0.0,<3.0.0',
         'MulticoreTSNE',
         'Click',
         'umap-learn<0.4.0',

--- a/setup.py
+++ b/setup.py
@@ -49,7 +49,7 @@ setup(
         'Click<8',
         'umap-learn<0.4.0',
         'harmonypy>=0.0.5',
-        'bbknn>=1.5.1',
+        'bbknn>=1.3.12',
         'mnnpy>=0.1.9.5'
     ],
 )

--- a/setup.py
+++ b/setup.py
@@ -49,7 +49,7 @@ setup(
         'Click<8',
         'umap-learn<0.4.0',
         'harmonypy>=0.0.5',
-        'bbknn>=1.3.12',
+        'bbknn>=1.3.12,<1.5.0',
         'mnnpy>=0.1.9.5'
     ],
 )

--- a/setup.py
+++ b/setup.py
@@ -44,6 +44,7 @@ setup(
         'scanpy>=1.6.0',
         'louvain',
         'leidenalg',
+        'loompy',
         'MulticoreTSNE',
         'Click',
         'umap-learn<0.4.0',

--- a/setup.py
+++ b/setup.py
@@ -49,7 +49,7 @@ setup(
         'Click<8',
         'umap-learn<0.4.0',
         'harmonypy>=0.0.5',
-        'bbknn>=1.3.12',
+        'bbknn>=1.5.1',
         'mnnpy>=0.1.9.5'
     ],
 )

--- a/setup.py
+++ b/setup.py
@@ -46,7 +46,7 @@ setup(
         'leidenalg',
         'loompy',
         'MulticoreTSNE',
-        'Click',
+        'Click<8',
         'umap-learn<0.4.0',
         'harmonypy>=0.0.5',
         'bbknn>=1.3.12',


### PR DESCRIPTION
Since we removed the specialised loom handling in  https://github.com/ebi-gene-expression-group/scanpy-scripts/pull/84, and the Loom pinning is causing issues like https://github.com/ebi-gene-expression-group/scanpy-scripts/issues/98, we should just unpin and leave to the upstream dependencies. 

This will probably have to be propagated to the Bioconda recipe too.

Also had to pin cmake for Multicore-tSNSE (see https://github.com/conda-forge/multicore-tsne-feedstock/pull/6)- this may be necessary until that package's version is bumped.