### PR TITLE
Make sure that paga without basis uses color if given

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -8,7 +8,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [3.6, 3.7, 3.8]
+        python-version: [3.7, 3.8]
 
     steps:
     - uses: actions/checkout@v2

--- a/scanpy_scripts/cmd_options.py
+++ b/scanpy_scripts/cmd_options.py
@@ -1818,10 +1818,10 @@ CMD_OPTIONS = {
         ),
         click.option(
             '--color',
-            type=click.STRING,
+            type=type=CommaSeparatedText(simplify=True),
             default=None,
             show_default=True,
-            help='Key for annotation of observations/cells or variables/genes.',
+            help='Key(s) for annotation of observations/cells or variables/genes. Comma-separated if more than one',
         ),
         click.option(
             '--legend-loc',

--- a/scanpy_scripts/cmd_options.py
+++ b/scanpy_scripts/cmd_options.py
@@ -232,7 +232,7 @@ COMMON_OPTIONS = {
 
     'use_raw': click.option(
         '--use-raw/--no-raw', 'use_raw',
-        default=True,
+        default=None,
         show_default=True,
         help='Use expression values in `.raw` if present.',
     ),

--- a/scanpy_scripts/cmd_options.py
+++ b/scanpy_scripts/cmd_options.py
@@ -1613,7 +1613,7 @@ CMD_OPTIONS = {
             'each cell. Set to 0 to skip.'
         ),
         click.option(
-            '--n-trees',
+            '--annoy-n-trees',
             type=click.INT,
             default=10,
             show_default=True,

--- a/scanpy_scripts/cmd_options.py
+++ b/scanpy_scripts/cmd_options.py
@@ -1818,7 +1818,7 @@ CMD_OPTIONS = {
         ),
         click.option(
             '--color',
-            type=type=CommaSeparatedText(simplify=True),
+            type=CommaSeparatedText(simplify=True),
             default=None,
             show_default=True,
             help='Key(s) for annotation of observations/cells or variables/genes. Comma-separated if more than one',

--- a/scanpy_scripts/lib/_diffexp.py
+++ b/scanpy_scripts/lib/_diffexp.py
@@ -8,7 +8,7 @@ import logging
 
 def diffexp(
         adata,
-        use_raw=True,
+        use_raw=None,
         n_genes=None,
         key_added='rank_genes_groups',
         layer=None,

--- a/scanpy_scripts/lib/_paga.py
+++ b/scanpy_scripts/lib/_paga.py
@@ -93,6 +93,7 @@ def plot_paga(
                 adata,
                 layout=layout,
                 init_pos=init_pos,
+                color=color,
                 title=title,
                 show=show,
                 save=save,

--- a/setup.py
+++ b/setup.py
@@ -41,7 +41,7 @@ setup(
         'matplotlib',
         'pandas',
         'h5py<3.0.0',
-        'scanpy>=1.6.0,<1.8.0',
+        'scanpy>=1.6.0',
         'louvain',
         'leidenalg',
         'loompy',

--- a/setup.py
+++ b/setup.py
@@ -41,7 +41,7 @@ setup(
         'matplotlib',
         'pandas',
         'h5py<3.0.0',
-        'scanpy>=1.6.0',
+        'scanpy>=1.6.0,<1.8.0',
         'louvain',
         'leidenalg',
         'loompy',

--- a/setup.py
+++ b/setup.py
@@ -49,7 +49,7 @@ setup(
         'Click<8',
         'umap-learn<0.4.0',
         'harmonypy>=0.0.5',
-        'bbknn>=1.3.12,<1.5.0',
+        'bbknn>=1.5.0',
         'mnnpy>=0.1.9.5'
     ],
 )


### PR DESCRIPTION
Currently paga is missing the color attribute, which should explain why when it is given on Galaxy on plot trajectory it has no effect:

```
scanpy-cli plot paga --use-key 'paga' --layout fa --legend-loc 'right margin' \
    --threshold 0.01  --solid-edges connectivities \
    --color 'cell_type,ENSMUSG00000023274,ENSMUSG00000053977' \
    --node-size-scale 1.0 --edge-width-scale 1.0 --show-obj stdout \
    --output-format anndata --output-obj output.h5  --input-format 'anndata' input.h5   \
    --fig-size '4,4' --fig-dpi 80 --fig-fontsize 10 --frameoff ./output.png
```

![image](https://user-images.githubusercontent.com/368478/124033704-320da480-d9f2-11eb-9b84-4b0a06da0fa9.png)

After the required releases everywhere, this should fix https://github.com/ebi-gene-expression-group/container-galaxy-sc-tertiary/issues/232