### PR TITLE
Always generate mito stats, even if not filtering by mito stats

### DIFF
--- a/scanpy_scripts/lib/_filter.py
+++ b/scanpy_scripts/lib/_filter.py
@@ -66,8 +66,15 @@ def filter_anndata(
             logging.warning('`pct_counts_%s` exists, not overwriting '
                             'without --force-recalc', pt)
             pct_top.remove(pt)
+
+    # Calculate mito stats if we can, even if we're not filtering by them   
+
+    if 'mito' not in qc_vars and 'mito' in adata.var.keys():
+        qc_vars.append('mito')
+
     sc.pp.calculate_qc_metrics(
         adata, layer=layer, qc_vars=qc_vars, percent_top=pct_top, inplace=True)
+
     adata.obs['n_counts'] = adata.obs['total_counts']
     adata.obs['n_genes'] = adata.obs['n_genes_by_counts']
     adata.var['n_counts'] = adata.var['total_counts']


### PR DESCRIPTION
Currently, we only get the mito stats (pct_counts_mito etc) if we're actually using those in filtering. This makes it so those stats are added whenever we have the mito column in .var.