### PR TITLE
Batch aware Scrublet

### DIFF
--- a/scanpy_scripts/cmd_options.py
+++ b/scanpy_scripts/cmd_options.py
@@ -1672,6 +1672,13 @@ CMD_OPTIONS = {
         *COMMON_OPTIONS['input'],
         *COMMON_OPTIONS['output'],
         click.option(
+            '--batch-key', 'batch_key',
+            type=click.STRING,
+            default=None,
+            help='The name of the column in adata.obs that differentiates among '
+            'experiments/batches. Doublets will be detected in each batch separately.'
+        ),
+        click.option(
             '--input-obj-sim', 'adata_sim',
             type=click.Path(exists=True, dir_okay=False),
             default=None,
@@ -1693,7 +1700,6 @@ CMD_OPTIONS = {
             'predicted doublets in a 2-D embedding.'
         ),
         *COMMON_OPTIONS['scrublet'],
-        COMMON_OPTIONS['batch_key'],
         click.option(
             '--expected-doublet-rate',
             type=click.FLOAT,

--- a/scanpy_scripts/cmd_options.py
+++ b/scanpy_scripts/cmd_options.py
@@ -1693,6 +1693,7 @@ CMD_OPTIONS = {
             'predicted doublets in a 2-D embedding.'
         ),
         *COMMON_OPTIONS['scrublet'],
+        COMMON_OPTIONS['batch_key'],
         click.option(
             '--expected-doublet-rate',
             type=click.FLOAT,

--- a/scanpy_scripts/lib/_scrublet.py
+++ b/scanpy_scripts/lib/_scrublet.py
@@ -26,11 +26,9 @@ def scrublet(adata, adata_sim=None, filter=False, batch_key=None, export_table=N
 
     alldata = []
     if batch_key is not None:
-        if batch_key in adata.obs.keys():
-            print("batch key %s is in obs" % batch_key)
-        else:
-            print("batch key %s is NOT in obs" % batch_key)
-        
+        if batch_key not in adata.obs.keys():
+            raise ValueError('`batch_key` must be a column of .obs in the input annData object.')
+
         batches = np.unique(adata.obs[batch_key])
     
         # Run Scrublet independently on batches and return just the

--- a/scanpy_scripts/lib/_scrublet.py
+++ b/scanpy_scripts/lib/_scrublet.py
@@ -21,7 +21,8 @@ def scrublet(adata, adata_sim=None, filter=False, batch_key=None, export_table=N
     if adata_sim:
         adata_sim = sc.read(adata_sim)
 
-    # Scrublet shouldn't be run on multi-batch data, so we split and recombine
+    # Scrublet shouldn't be run on multi-batch data, so we run the batches
+    # separately and copy the stats back to the input object
 
     alldata = []
     if batch_key is not None:


### PR DESCRIPTION
The Scrublet documentation states that we shouldn't be doing single run for multi-batch data. So this PR adds code to run any batches separately and combine the results. Filtering can then be done on the merged doublet calls. 

The batch-wise slices have to be copied rather than just being views, but I've tried to minimise the impact on memory by only saving the stats we need from each one. 

This should probably be pushed to the Scanpy codebase where the Scrublet wrapper lives, and I'll do that, but we need this fairly quickly and I don't want to wait for a Scanpy release. 