### PR TITLE
Fix mito calculations

### DIFF
--- a/scanpy_scripts/lib/_filter.py
+++ b/scanpy_scripts/lib/_filter.py
@@ -51,7 +51,6 @@ def filter_anndata(
     # Calculate mito stats if we can
 
     if 'mito' in adata.var.keys() and 'pct_counts_mito' not in adata.obs.keys():  
-        adata.var['mito'] = adata.var['mito'] == 'True'
         sc.pp.calculate_qc_metrics( adata, layer=layer, qc_vars=['mito'],
             percent_top = None, inplace=True)
 


### PR DESCRIPTION
This is a fix to https://github.com/ebi-gene-expression-group/scanpy-scripts/pull/104

That PR addressed the case where the mito column was pre-populated but mito filtering was NOT activated. Unfortunately when the mito column is pre-populated and the filtering by pct_counts_mito IS activated things fail because the column is not available yet (I hadn't understood that logic correctly). This fixes thing call sc.pp.calculate_qc_metrics() early in the process so the column becomes available for filtering at the time the columns are checked.