### PR TITLE
Remove batch handling in favour of scanpy-located code

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -44,5 +44,5 @@ jobs:
     
     - name: Test with bats
       run: |
-        ./scanpy-scripts-tests.bats
+        ./scanpy-scripts/scanpy-scripts-tests.bats
  

--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -12,6 +12,15 @@ jobs:
 
     steps:
     - uses: actions/checkout@v2
+      with:
+        path: scanpy-scripts
+
+    steps:
+    - uses: actions/checkout@v2
+      with:
+        repository: theislab/scanpy 
+        path: scanpy
+        ref: 1.8.1
     
     - name: Setup BATS
       uses: mig4/setup-bats@v1
@@ -25,14 +34,14 @@ jobs:
     
     - name: Install dependencies
       run: |
+        pushd scanpy
+        patch -p1 < ../scanpy-scripts.patch
+        popd
+
         sudo apt-get install libhdf5-dev
         pip install -U setuptools>=40.1 wheel 'cmake<3.20'
-        pip install .
-        wget https://github.com/theislab/scanpy/archive/refs/tags/1.8.1.tar.gz
-        tar -xvzf 1.8.1.tar.gz
-        cd scanpy-1.8.1
-        patch -p1 < ../scrublet.patch
-        python -m pip install . --no-deps --ignore-installed -vv
+        pip install $(pwd)/scanpy-scripts
+        python -m pip install $(pwd)/scanpy --no-deps --ignore-installed -vv
     
     - name: Test with bats
       run: |

--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -34,7 +34,7 @@ jobs:
     - name: Install dependencies
       run: |
         pushd scanpy
-        patch -p1 < ../scanpy-scripts.patch
+        patch -p1 < ../scanpy-scripts/scrublet.patch
         popd
 
         sudo apt-get install libhdf5-dev

--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -31,7 +31,7 @@ jobs:
         wget https://github.com/theislab/scanpy/archive/refs/tags/1.8.1.tar.gz
         tar -xvzf 1.8.1.tar.gz
         cd scanpy-1.8.1
-        patch -p1 < $PREFIX/scrublet.patch
+        patch -p1 < ../scrublet.patch
         python -m pip install . --no-deps --ignore-installed -vv
     
     - name: Test with bats

--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -28,6 +28,11 @@ jobs:
         sudo apt-get install libhdf5-dev
         pip install -U setuptools>=40.1 wheel 'cmake<3.20'
         pip install .
+        wget https://github.com/theislab/scanpy/archive/refs/tags/1.8.1.tar.gz
+        tar -xvzf 1.8.1.tar.gz
+        cd scanpy-1.8.1
+        patch -p1 < $PREFIX/scrublet.patch
+        python -m pip install . --no-deps --ignore-installed -vv
     
     - name: Test with bats
       run: |

--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -15,7 +15,6 @@ jobs:
       with:
         path: scanpy-scripts
 
-    steps:
     - uses: actions/checkout@v2
       with:
         repository: theislab/scanpy 

--- a/scanpy_scripts/cmd_options.py
+++ b/scanpy_scripts/cmd_options.py
@@ -1674,7 +1674,6 @@ CMD_OPTIONS = {
         click.option(
             '--batch-key', 'batch_key',
             type=click.STRING,
-            default=None,
             help='The name of the column in adata.obs that differentiates among '
             'experiments/batches. Doublets will be detected in each batch separately.'
         ),

--- a/scanpy_scripts/lib/_scrublet.py
+++ b/scanpy_scripts/lib/_scrublet.py
@@ -11,7 +11,7 @@ import pandas as pd
 
 # Wrapper for scrublet allowing text export and filtering
 
-def scrublet(adata, adata_sim=None, filter=False, batch_key=None, export_table=None, **kwargs):
+def scrublet(adata, adata_sim=None, filter=False, export_table=None, **kwargs):
     """
     Wrapper function for sce.pp.scrublet(), to allow filtering of resulting object
     """
@@ -21,35 +21,7 @@ def scrublet(adata, adata_sim=None, filter=False, batch_key=None, export_table=N
     if adata_sim:
         adata_sim = sc.read(adata_sim)
 
-    # Scrublet shouldn't be run on multi-batch data, so we run the batches
-    # separately and copy the stats back to the input object
-
-    alldata = []
-    if batch_key is not None:
-        if batch_key not in adata.obs.keys():
-            raise ValueError('`batch_key` must be a column of .obs in the input annData object.')
-
-        batches = np.unique(adata.obs[batch_key])
-    
-        # Run Scrublet independently on batches and return just the
-        # scrublet-relevant parts of the objects to add to the input object
-
-        def get_adata_scrub_parts(ad):
-            return {'obs': ad.obs, 'uns': ad.uns['scrublet']}
-
-        scrubbed = [ get_adata_scrub_parts(sce.pp.scrublet(adata[adata.obs[batch_key] == batch,], adata_sim=adata_sim, copy = True, **kwargs)) for batch in batches ] 
-        scrubbed_obs = pd.concat([ scrub['obs'] for scrub in scrubbed])        
-
-        # Now reset the obs to get the scrublet scores
-        
-        adata.obs = scrubbed_obs.loc[adata.obs_names.values]
-
-        # Save the .uns from each batch separately
-    
-        adata.uns['scrublet'] = dict(zip(batches, [ scrub['uns'] for scrub in scrubbed ]))
-
-    else:
-        sce.pp.scrublet(adata, adata_sim=adata_sim, **kwargs)
+    sce.pp.scrublet(adata, adata_sim=adata_sim, **kwargs)
     
     # Do any export before optional filtering
 

--- a/scrublet.patch
+++ b/scrublet.patch
@@ -1,0 +1,328 @@
+diff --git a/scanpy/external/pl.py b/scanpy/external/pl.py
+index 629b40cc..6eb61c48 100644
+--- a/scanpy/external/pl.py
++++ b/scanpy/external/pl.py
+@@ -340,6 +340,8 @@ def scrublet_score_distribution(
+     The histogram for simulated doublets is useful for determining the correct doublet
+     score threshold.
+ 
++    Scrublet must have been run previously with the input object.
++
+     Parameters
+     ----------
+     adata
+@@ -372,40 +374,86 @@ def scrublet_score_distribution(
+         simulation separately for advanced usage.
+     """
+ 
+-    threshold = adata.uns['scrublet']['threshold']
+-    fig, axs = plt.subplots(1, 2, figsize=figsize)
++    if 'scrublet' not in adata.uns:
++        raise ValueError(
++            'Please run scrublet before trying to generate the scrublet plot.'
++        )
+ 
+-    ax = axs[0]
+-    ax.hist(
+-        adata.obs['doublet_score'],
+-        np.linspace(0, 1, 50),
+-        color='gray',
+-        linewidth=0,
+-        density=True,
+-    )
+-    ax.set_yscale(scale_hist_obs)
+-    yl = ax.get_ylim()
+-    ax.set_ylim(yl)
+-    ax.plot(threshold * np.ones(2), yl, c='black', linewidth=1)
+-    ax.set_title('Observed transcriptomes')
+-    ax.set_xlabel('Doublet score')
+-    ax.set_ylabel('Prob. density')
+-
+-    ax = axs[1]
+-    ax.hist(
+-        adata.uns['scrublet']['doublet_scores_sim'],
+-        np.linspace(0, 1, 50),
+-        color='gray',
+-        linewidth=0,
+-        density=True,
+-    )
+-    ax.set_yscale(scale_hist_sim)
+-    yl = ax.get_ylim()
+-    ax.set_ylim(yl)
+-    ax.plot(threshold * np.ones(2), yl, c='black', linewidth=1)
+-    ax.set_title('Simulated doublets')
+-    ax.set_xlabel('Doublet score')
+-    ax.set_ylabel('Prob. density')
++    # If batched_by is populated, then we know Scrublet was run over multiple batches
++
++    if 'batched_by' in adata.uns['scrublet']:
++        batch_key = adata.uns['scrublet']['batched_by']
++
++        batches = np.unique(adata.obs[batch_key])
++        adatas = [
++            adata[
++                adata.obs[batch_key] == batch,
++            ]
++            for batch in batches
++        ]
++        figsize = (figsize[0], figsize[1] * len(batches))
++
++    else:
++        adatas = [adata]
++
++    fig, axs = plt.subplots(len(adatas), 2, figsize=figsize)
++
++    for idx, ad in enumerate(adatas):
++
++        # We'll need multiple rows if Scrublet was run in multiple batches
++
++        if 'batched_by' in adata.uns['scrublet']:
++
++            batch = batches[idx]
++
++            threshold = adata.uns['scrublet']['batches'][batch]['threshold']
++            doublet_scores_sim = adata.uns['scrublet']['batches'][batch][
++                'doublet_scores_sim'
++            ]
++            axis_lab_suffix = " (%s)" % batch
++            obs_ax = axs[idx][0]
++            sim_ax = axs[idx][1]
++
++        else:
++            threshold = adata.uns['scrublet']['threshold']
++            doublet_scores_sim = adata.uns['scrublet']['doublet_scores_sim']
++            axis_lab_suffix = ''
++            obs_ax = axs[0]
++            sim_ax = axs[1]
++
++        # Make the observed transcriptomes plot
++
++        obs_ax.hist(
++            ad.obs['doublet_score'],
++            np.linspace(0, 1, 50),
++            color='gray',
++            linewidth=0,
++            density=True,
++        )
++        obs_ax.set_yscale(scale_hist_obs)
++        yl = obs_ax.get_ylim()
++        obs_ax.set_ylim(yl)
++        obs_ax.plot(threshold * np.ones(2), yl, c='black', linewidth=1)
++        obs_ax.set_title('Observed transcriptomes%s' % axis_lab_suffix)
++        obs_ax.set_xlabel('Doublet score')
++        obs_ax.set_ylabel('Prob. density')
++
++        # Make the simulated tranascriptomes plot
++
++        sim_ax.hist(
++            doublet_scores_sim,
++            np.linspace(0, 1, 50),
++            color='gray',
++            linewidth=0,
++            density=True,
++        )
++        sim_ax.set_yscale(scale_hist_sim)
++        yl = sim_ax.get_ylim()
++        sim_ax.set_ylim(yl)
++        sim_ax.plot(threshold * np.ones(2), yl, c='black', linewidth=1)
++        sim_ax.set_title('Simulated doublets%s' % axis_lab_suffix)
++        sim_ax.set_xlabel('Doublet score')
++        sim_ax.set_ylabel('Prob. density')
+ 
+     fig.tight_layout()
+ 
+diff --git a/scanpy/external/pp/_scrublet.py b/scanpy/external/pp/_scrublet.py
+index 7ebb7b5b..85682088 100644
+--- a/scanpy/external/pp/_scrublet.py
++++ b/scanpy/external/pp/_scrublet.py
+@@ -1,6 +1,7 @@
+ from anndata import AnnData
+ from typing import Optional
+ import numpy as np
++import pandas as pd
+ from scipy import sparse
+ 
+ 
+@@ -12,6 +13,7 @@ from ...get import _get_obs_rep
+ def scrublet(
+     adata: AnnData,
+     adata_sim: Optional[AnnData] = None,
++    batch_key: str = None,
+     sim_doublet_ratio: float = 2.0,
+     expected_doublet_rate: float = 0.05,
+     stdev_doublet_rate: float = 0.02,
+@@ -60,6 +62,8 @@ def scrublet(
+         sc.external.pp.scrublet_simulate_doublets(), with same number of vars
+         as adata. This should have been built from adata_obs after
+         filtering genes and cells and selcting highly-variable genes.
++    batch_key
++        Optional `adata.obs` column name discriminating between batches.
+     sim_doublet_ratio
+         Number of doublets to simulate relative to the number of observed
+         transcriptomes.
+@@ -161,72 +165,114 @@ def scrublet(
+ 
+     adata_obs = adata.copy()
+ 
+-    # With no adata_sim we assume the regular use case, starting with raw
+-    # counts and simulating doublets
++    def _run_scrublet(ad_obs, ad_sim=None):
+ 
+-    if not adata_sim:
++        # With no adata_sim we assume the regular use case, starting with raw
++        # counts and simulating doublets
+ 
+-        pp.filter_genes(adata_obs, min_cells=3)
+-        pp.filter_cells(adata_obs, min_genes=3)
++        if ad_sim is None:
+ 
+-        # Doublet simulation will be based on the un-normalised counts, but on the
+-        # selection of genes following normalisation and variability filtering. So
+-        # we need to save the raw and subset at the same time.
++            pp.filter_genes(ad_obs, min_cells=3)
++            pp.filter_cells(ad_obs, min_genes=3)
+ 
+-        adata_obs.layers['raw'] = adata_obs.X
+-        pp.normalize_total(adata_obs)
++            # Doublet simulation will be based on the un-normalised counts, but on the
++            # selection of genes following normalisation and variability filtering. So
++            # we need to save the raw and subset at the same time.
+ 
+-        # HVG process needs log'd data. If we're not using that downstream, then
+-        # copy logged data to new object and subset original object based on the
+-        # output.
++            ad_obs.layers['raw'] = ad_obs.X.copy()
++            pp.normalize_total(ad_obs)
+ 
+-        if log_transform:
+-            pp.log1p(adata_obs)
+-            pp.highly_variable_genes(adata_obs, subset=True)
+-        else:
+-            logged = pp.log1p(adata_obs, copy=True)
+-            _ = pp.highly_variable_genes(logged)
+-            adata_obs = adata_obs[:, logged.var['highly_variable']]
++            # HVG process needs log'd data.
+ 
+-        # Simulate the doublets based on the raw expressions from the normalised
+-        # and filtered object.
++            logged = pp.log1p(ad_obs, copy=True)
++            pp.highly_variable_genes(logged)
++            ad_obs = ad_obs[:, logged.var['highly_variable']]
+ 
+-        adata_sim = scrublet_simulate_doublets(
+-            adata_obs,
+-            layer='raw',
+-            sim_doublet_ratio=sim_doublet_ratio,
+-            synthetic_doublet_umi_subsampling=synthetic_doublet_umi_subsampling,
++            # Simulate the doublets based on the raw expressions from the normalised
++            # and filtered object.
++
++            ad_sim = scrublet_simulate_doublets(
++                ad_obs,
++                layer='raw',
++                sim_doublet_ratio=sim_doublet_ratio,
++                synthetic_doublet_umi_subsampling=synthetic_doublet_umi_subsampling,
++            )
++
++            # Now normalise simulated and observed in the same way
++
++            pp.normalize_total(ad_obs, target_sum=1e6)
++            pp.normalize_total(ad_sim, target_sum=1e6)
++
++            if log_transform:
++                pp.log1p(ad_obs)
++                pp.log1p(ad_sim)
++
++        ad_obs = _scrublet_call_doublets(
++            adata_obs=ad_obs,
++            adata_sim=ad_sim,
++            n_neighbors=n_neighbors,
++            expected_doublet_rate=expected_doublet_rate,
++            stdev_doublet_rate=stdev_doublet_rate,
++            mean_center=mean_center,
++            normalize_variance=normalize_variance,
++            n_prin_comps=n_prin_comps,
++            use_approx_neighbors=use_approx_neighbors,
++            knn_dist_metric=knn_dist_metric,
++            get_doublet_neighbor_parents=get_doublet_neighbor_parents,
++            threshold=threshold,
++            random_state=random_state,
++            verbose=verbose,
+         )
+ 
+-        # Now normalise simulated and observed in the same way
++        return {'obs': ad_obs.obs, 'uns': ad_obs.uns['scrublet']}
+ 
+-        pp.normalize_total(adata_obs, target_sum=1e6)
+-        pp.normalize_total(adata_sim, target_sum=1e6)
++    if batch_key is not None:
++        if batch_key not in adata.obs.keys():
++            raise ValueError(
++                '`batch_key` must be a column of .obs in the input annData object.'
++            )
+ 
+-    adata_obs = _scrublet_call_doublets(
+-        adata_obs=adata_obs,
+-        adata_sim=adata_sim,
+-        n_neighbors=n_neighbors,
+-        expected_doublet_rate=expected_doublet_rate,
+-        stdev_doublet_rate=stdev_doublet_rate,
+-        mean_center=mean_center,
+-        normalize_variance=normalize_variance,
+-        n_prin_comps=n_prin_comps,
+-        use_approx_neighbors=use_approx_neighbors,
+-        knn_dist_metric=knn_dist_metric,
+-        get_doublet_neighbor_parents=get_doublet_neighbor_parents,
+-        threshold=threshold,
+-        random_state=random_state,
+-        verbose=verbose,
+-    )
++        # Run Scrublet independently on batches and return just the
++        # scrublet-relevant parts of the objects to add to the input object
+ 
+-    logg.info('    Scrublet finished', time=start)
++        batches = np.unique(adata.obs[batch_key])
++        scrubbed = [
++            _run_scrublet(
++                adata_obs[
++                    adata_obs.obs[batch_key] == batch,
++                ],
++                adata_sim,
++            )
++            for batch in batches
++        ]
++        scrubbed_obs = pd.concat([scrub['obs'] for scrub in scrubbed])
++
++        # Now reset the obs to get the scrublet scores
++
++        adata.obs = scrubbed_obs.loc[adata.obs_names.values]
++
++        # Save the .uns from each batch separately
++
++        adata.uns['scrublet'] = {}
++        adata.uns['scrublet']['batches'] = dict(
++            zip(batches, [scrub['uns'] for scrub in scrubbed])
++        )
+ 
+-    # Copy outcomes to input object from our processed version
++        # Record that we've done batched analysis, so e.g. the plotting
++        # function knows what to do.
+ 
+-    adata.obs['doublet_score'] = adata_obs.obs['doublet_score']
+-    adata.obs['predicted_doublet'] = adata_obs.obs['predicted_doublet']
+-    adata.uns['scrublet'] = adata_obs.uns['scrublet']
++        adata.uns['scrublet']['batched_by'] = batch_key
++
++    else:
++        scrubbed = _run_scrublet(adata_obs, adata_sim)
++
++        # Copy outcomes to input object from our processed version
++
++        adata.obs['doublet_score'] = scrubbed['obs']['doublet_score']
++        adata.obs['predicted_doublet'] = scrubbed['obs']['predicted_doublet']
++        adata.uns['scrublet'] = scrubbed['uns']
++
++    logg.info('    Scrublet finished', time=start)
+ 
+     if copy:
+         return adata

--- a/setup.py
+++ b/setup.py
@@ -41,7 +41,7 @@ setup(
         'matplotlib',
         'pandas',
         'h5py<3.0.0',
-        'scanpy=1.8.1',
+        'scanpy==1.8.1',
         'louvain',
         'leidenalg',
         'loompy',

--- a/setup.py
+++ b/setup.py
@@ -41,7 +41,7 @@ setup(
         'matplotlib',
         'pandas',
         'h5py<3.0.0',
-        'scanpy>=1.8.0',
+        'scanpy=1.8.1',
         'louvain',
         'leidenalg',
         'loompy',


### PR DESCRIPTION
There is a [bug](https://github.com/theislab/scanpy/issues/1957) in the Scrublet wrapper I contributed to Scanpy, which does seem quite important and was creating some weird results in my testing. 

I've submitted a [fix](https://github.com/theislab/scanpy/issues/1957) for that, and at the same time proposed the relocation of batch-handing code from here to there. I was going to need to re-write the Scrublet plotting function anyway, to deal with batches since I was having trouble wrapping the outputs here in a batch-aware way, so it made sense just to improve the upstream Scanpy code while I was fixing the bug.

I've therefore cut the batch handling out of this module again, and hopefully it can be handled by the upstream code once the Scanpy people approve. I will add a patch to our Bioconda recipe to apply a patch to add that functionality, pending a release (which can be a while with Scanpy).