### PR TITLE
Adding fa2 to install so that trajectory tools can use it for setting up the plots 

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -52,6 +52,7 @@ setup(
         'bbknn>=1.5.0',
         'mnnpy>=0.1.9.5',
         'scrublet',
-        'scikit-misc'
+        'scikit-misc',
+        'fa2'
     ],
 )


### PR DESCRIPTION
[Which otherwise, for RunFDG, throw this: WARNING: Package 'fa2' is not installed, falling back to layout 'fr'.To use the faster and better ForceAtlas2 layout, install package 'fa2' (`pip install fa2`).