### PR TITLE
Fix boolean columns during merges of extra info at read time

### DIFF
--- a/scanpy_scripts/cmd_utils.py
+++ b/scanpy_scripts/cmd_utils.py
@@ -72,6 +72,15 @@ def add_options(options):
         return func
     return _add_options
 
+def _fix_booleans(df):
+  for var in df.columns:
+    if (df[var].dtype.kind == 'O' and 
+        df[var].dtype.name == 'object' and 
+        set(pd.Categorical(df[var])).issubset(set(['True', 'False', 'nan']))
+        ):
+      d = {'False': True, 'False': False, 'nan': False}
+      df[var] = df[var].map(d).astype(bool)
+  return(df)
 
 def _read_obj(input_obj, input_format='anndata', **kwargs):
     if input_format == 'anndata':
@@ -81,8 +90,10 @@ def _read_obj(input_obj, input_format='anndata', **kwargs):
     else:
         raise NotImplementedError(
             'Unsupported input format: {}'.format(input_format))
-    return adata
+    adata.var = _fix_booleans(adata.var)
+    adata.obs = _fix_booleans(adata.obs)
 
+    return adata
 
 def _write_obj(
         adata,

--- a/scanpy_scripts/lib/_read.py
+++ b/scanpy_scripts/lib/_read.py
@@ -48,7 +48,7 @@ def _fix_booleans(df):
   for var in df.columns:
     if (df[var].dtype.kind == 'O' and 
         df[var].dtype.name == 'object' and 
-        set(pd.Categorical(df[var][df[var] != 'nan'])).issubset(set(['True', 'False']))
+        set(pd.Categorical(df[var])).issubset(set(['True', 'False', 'nan']))
         ):
       d = {'False': True, 'False': False}
       df[var] = df[var].map(d)

--- a/scanpy_scripts/lib/_read.py
+++ b/scanpy_scripts/lib/_read.py
@@ -25,21 +25,31 @@ def read_10x(
 
     if extra_obs:
         obs_tbl = pd.read_csv(extra_obs, sep='\t', header=0, index_col=0)
-        adata.obs = adata.obs.merge(
+        adata.obs = _fix_booleans(adata.obs.merge(
             obs_tbl,
             how='left',
             left_index=True,
             right_index=True,
             suffixes=(False, False),
-        )
+        ))
 
     if extra_var:
         var_tbl = pd.read_csv(extra_var, sep='\t', header=0, index_col=0)
-        adata.var = adata.var.merge(
+        adata.var = _fix_booleans(adata.var.merge(
             var_tbl,
             how='left',
             left_index=True,
             right_index=True,
             suffixes=(False, False),
-        )
+        ))
     return adata
+
+def _fix_booleans(df):
+  for var in df.columns:
+    if (df[var].dtype.kind == 'O' and 
+        df[var].dtype.name == 'object' and 
+        set(pd.Categorical(df[var][df[var] != 'nan'])).issubset(set(['True', 'False']))
+        ):
+      d = {'False': True, 'False': False}
+      df[var] = df[var].map(d)
+  return(df)

--- a/scanpy_scripts/lib/_read.py
+++ b/scanpy_scripts/lib/_read.py
@@ -25,31 +25,21 @@ def read_10x(
 
     if extra_obs:
         obs_tbl = pd.read_csv(extra_obs, sep='\t', header=0, index_col=0)
-        adata.obs = _fix_booleans(adata.obs.merge(
+        adata.obs = adata.obs.merge(
             obs_tbl,
             how='left',
             left_index=True,
             right_index=True,
             suffixes=(False, False),
-        ))
+        )
 
     if extra_var:
         var_tbl = pd.read_csv(extra_var, sep='\t', header=0, index_col=0)
-        adata.var = _fix_booleans(adata.var.merge(
+        adata.var = adata.var.merge(
             var_tbl,
             how='left',
             left_index=True,
             right_index=True,
             suffixes=(False, False),
-        ))
+        )
     return adata
-
-def _fix_booleans(df):
-  for var in df.columns:
-    if (df[var].dtype.kind == 'O' and 
-        df[var].dtype.name == 'object' and 
-        set(pd.Categorical(df[var][df[var] != 'nan'])).issubset(set(['True', 'False']))
-        ):
-      d = {'False': True, 'False': False}
-      df[var] = df[var].map(d)
-  return(df)

--- a/scanpy_scripts/lib/_read.py
+++ b/scanpy_scripts/lib/_read.py
@@ -48,7 +48,7 @@ def _fix_booleans(df):
   for var in df.columns:
     if (df[var].dtype.kind == 'O' and 
         df[var].dtype.name == 'object' and 
-        set(pd.Categorical(df[var])).issubset(set(['True', 'False', 'nan']))
+        set(pd.Categorical(df[var][df[var] != 'nan'])).issubset(set(['True', 'False']))
         ):
       d = {'False': True, 'False': False}
       df[var] = df[var].map(d)


### PR DESCRIPTION
Currently, if extra obs or var are supplied at read time and cover all the obs or var, boolean string columns from the extras ('True', 'False') are interpreted correctly and become booleans.

If the extra obs or var do NOT cover all the obs or var in the input (e.g. where the matrix contains spikes), then the column instead becomes a pandas 'object' column, with string values 'True', 'False' and 'nan', with the 'nan' values added for the missing ones.

I don't see a way to tweak the merge call to fix this directly, but we can detect when a column consists entirely of 'True', 'False' and 'nan', and fix accordingly- which is what this PR does. 

I considered setting the 'nan' to 'False', but decided against it, I think we're better making explicitly a missing value in a boolean column. 

The use case which triggered this was 'mito', which we supply from the script which derives gene annotations. The mito column in the above situation cannot cannot currently be used correctly in the filtering step because it's not interpreted as boolean and doesn't then lead to pct_mito being calculated. Since we're introducing mitochondrial filtering into our standard pipelines this is a necessary fix.

**Correction, 24/9**

Actually, the issue was not with MTX reading, it's due to the way anndata (probably hdf5 itself) was storing the NaNs on disk. So we actually need to institute a fix whenever the anndata object is read. Also, boolean columns are not nullable, so the empty values need to be False after all. 