### PR TITLE
Add compression option to export

### DIFF
--- a/scanpy-scripts-tests.bats
+++ b/scanpy-scripts-tests.bats
@@ -13,8 +13,9 @@ setup() {
     batch_obs="${data_dir}/batch_obs.txt"
     read_opt="-x $data_dir --show-obj stdout"
     read_obj="${output_dir}/read.h5ad"
-    filter_opt="--save-raw -p n_genes 200 2500 -p c:n_counts 0 50000 -p n_cells 3 inf -p pct_counts_mito 0 0.2 -c mito '!True' --show-obj stdout"
+    filter_opt="--save-raw -p n_genes 200 2500 -p c:n_counts 0 50000 -p n_cells 3 inf -p pct_counts_mito 0 0.2 -c mito '!True' --show-obj stdout --export-mtx ${output_dir}/filtered --mtx-compression gzip"
     filter_obj="${output_dir}/filter.h5ad"
+    filter_mtx_gz="${output_dir}/filtered_matrix.mtx.gz"
     test_clustering='louvain_k10_r0_5'
     scrublet_tsv="${output_dir}/scrublet.tsv"
     scrublet_png="${output_dir}/scrublet.png"
@@ -189,6 +190,7 @@ setup() {
 
     [ "$status" -eq 0 ]
     [ -f  "$filter_obj" ]
+    [ -f  "$filter_mtx_gz" ]
 }
 
 # Normalise

--- a/scanpy_scripts/cmd_options.py
+++ b/scanpy_scripts/cmd_options.py
@@ -69,6 +69,14 @@ COMMON_OPTIONS = {
             "appended.",
         ),
         click.option(
+            "--mtx-compression",
+            "-G",
+            type=click.Choice(["zip", "gzip", "bz2", "zstd"]),
+            default=None,
+            show_default=True,
+            help="Compression type for MTX output.",
+        ),
+        click.option(
             "--show-obj",
             type=click.Choice(["stdout", "stderr"]),
             default=None,

--- a/scanpy_scripts/cmd_utils.py
+++ b/scanpy_scripts/cmd_utils.py
@@ -38,6 +38,7 @@ def make_subcmd(cmd_name, func, cmd_desc, arg_desc, opt_set=None):
         zarr_chunk_size=None,
         loom_write_obsm_varm=False,
         export_mtx=None,
+        mtx_compression=None,
         show_obj=None,
         **kwargs,
     ):
@@ -56,6 +57,7 @@ def make_subcmd(cmd_name, func, cmd_desc, arg_desc, opt_set=None):
                 chunk_size=zarr_chunk_size,
                 write_obsm_varm=loom_write_obsm_varm,
                 export_mtx=export_mtx,
+                mtx_compression=mtx_compression,
                 show_obj=show_obj,
             )
         return 0
@@ -107,6 +109,7 @@ def _write_obj(
     output_format="anndata",
     chunk_size=None,
     export_mtx=None,
+    mtx_compression=None,
     show_obj=None,
     write_obsm_varm=False,
     **kwargs,
@@ -120,7 +123,11 @@ def _write_obj(
     else:
         raise NotImplementedError("Unsupported output format: {}".format(output_format))
     if export_mtx:
-        write_mtx(adata, fname_prefix=export_mtx, **kwargs)
+        compression = None
+        if mtx_compression is not None:
+            compression = {"method": mtx_compression}
+
+        write_mtx(adata, fname_prefix=export_mtx, compression=compression, **kwargs)
     if show_obj:
         click.echo(adata, err=show_obj == "stderr")
     return 0


### PR DESCRIPTION
This PR makes the changes from https://github.com/ebi-gene-expression-group/scanpy-scripts/pull/112 available via the command-line interface so we can actually leverage that direct compression in our Galaxy tools etc.