### PR TITLE
Remove extra pinning for mmnpy

### DIFF
--- a/test-env.yaml
+++ b/test-env.yaml
@@ -14,11 +14,8 @@ dependencies:
   - bbknn>=1.5.0,<1.6.0
   - mnnpy>=0.1.9.5
   # for mnnpy using n_jobs
-  - scipy <1.8.1
-  - scikit-learn <1.2.0
-  - numba <0.56
-  - numpy <1.22
-  - llvmlite <0.38.1
+  - scipy <1.9.0
+  - scikit-learn <1.3.0
   - scrublet
   - fa2
   # for testing


### PR DESCRIPTION
There were some extra pinnings that given that we are not supporting mmnpy we don't need anymore.