### PR TITLE
Change deprecated sc.read() usages for read_h5ad call

### DIFF
--- a/scanpy_scripts/cmd_utils.py
+++ b/scanpy_scripts/cmd_utils.py
@@ -93,7 +93,7 @@ def _fix_booleans(df):
 
 def _read_obj(input_obj, input_format="anndata", **kwargs):
     if input_format == "anndata":
-        adata = sc.read(input_obj, **kwargs)
+        adata = sc.read_h5ad(input_obj, **kwargs)
     elif input_format == "loom":
         adata = sc.read_loom(input_obj, **kwargs)
     else:

--- a/scanpy_scripts/lib/_scrublet.py
+++ b/scanpy_scripts/lib/_scrublet.py
@@ -2,12 +2,13 @@
 scanpy external scrublet
 """
 
+import anndata
+import numpy as np
+import pandas as pd
 import scanpy as sc
 import scanpy.external as sce
-import numpy as np
+
 from ..obj_utils import write_obs
-import anndata
-import pandas as pd
 
 # Wrapper for scrublet allowing text export and filtering
 
@@ -20,7 +21,7 @@ def scrublet(adata, adata_sim=None, filter=False, export_table=None, **kwargs):
     # Do we need to read an object with the doublet simulations?
 
     if adata_sim:
-        adata_sim = sc.read(adata_sim)
+        adata_sim = sc.read_h5ad(adata_sim)
 
     sce.pp.scrublet(adata, adata_sim=adata_sim, **kwargs)
 


### PR DESCRIPTION
This is to handle:

```
/usr/local/lib/python3.9/site-packages/anndata/__init__.py:51: FutureWarning: `anndata.read` is deprecated, use `anndata.read_h5ad` instead. `ad.read` will be removed in mid 2024.
```