### PR TITLE
Add option to set default number of jobs/CPUs to use

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -22,7 +22,7 @@ jobs:
       uses: mamba-org/provision-with-micromamba@main
       with:
         environment-file: test-env.yaml
-        cache-downloads: false
+        cache-downloads: true
         channels: conda-forge, bioconda, defaults
         extra-specs: |
           python=${{ matrix.python-version }}

--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -22,7 +22,7 @@ jobs:
       uses: mamba-org/provision-with-micromamba@main
       with:
         environment-file: test-env.yaml
-        cache-downloads: true
+        cache-downloads: false
         channels: conda-forge, bioconda, defaults
         extra-specs: |
           python=${{ matrix.python-version }}

--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -23,8 +23,12 @@ jobs:
       with:
         environment-file: test-env.yaml
         cache-downloads: true
-        channels: conda-forge, bioconda, defaults
-        extra-specs: |
+        condarc: |
+          channels: 
+            - conda-forge
+            - bioconda
+            - defaults
+        create-args: |
           python=${{ matrix.python-version }}
 
     - name: Run black manually

--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -19,7 +19,7 @@ jobs:
     - uses: actions/checkout@v2
     
     - name: Setup mamba
-      uses: mamba-org/provision-with-micromamba@main
+      uses: mamba-org/setup-micromamba@v2
       with:
         environment-file: test-env.yaml
         cache-downloads: true

--- a/README.md
+++ b/README.md
@@ -42,6 +42,7 @@ Usage: scanpy-cli [OPTIONS] COMMAND [ARGS]...
 Options:
   --debug              Print debug information
   --verbosity INTEGER  Set scanpy verbosity
+  --njobs INTEGER      Set scanpy default number of jobs/CPUs, defaults to all available
   --version            Show the version and exit.
   --help               Show this message and exit.
 

--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ Usage: scanpy-cli [OPTIONS] COMMAND [ARGS]...
 Options:
   --debug              Print debug information
   --verbosity INTEGER  Set scanpy verbosity
-  --njobs INTEGER      Set scanpy default number of jobs/CPUs, defaults to all available
+  --njobs INTEGER      Set scanpy default number of jobs/CPUs, defaults to 1
   --version            Show the version and exit.
   --help               Show this message and exit.
 

--- a/scanpy_scripts/cli.py
+++ b/scanpy_scripts/cli.py
@@ -53,6 +53,12 @@ from .cmds import (
     default=3,
     help="Set scanpy verbosity",
 )
+@click.option(
+    "--default_njobs",
+    type=click.INT,
+    default=-1,
+    help="Set scanpy default number of jobs",
+)
 @click.version_option(
     version="0.2.0",
     prog_name="scanpy",
@@ -71,6 +77,7 @@ def cli(debug=False, verbosity=3):
     )
     logging.debug("debugging")
     sc.settings.verbosity = verbosity
+    sc.settings.n_jobs = default_njobs
     return 0
 
 

--- a/scanpy_scripts/cli.py
+++ b/scanpy_scripts/cli.py
@@ -57,7 +57,7 @@ from .cmds import (
     "--njobs",
     type=click.INT,
     default=1,
-    help="Set scanpy default number of jobs/CPUs, defaults to all available",
+    help="Set scanpy default number of jobs/CPUs, defaults 1",
 )
 @click.version_option(
     version="0.2.0",

--- a/scanpy_scripts/cli.py
+++ b/scanpy_scripts/cli.py
@@ -54,16 +54,16 @@ from .cmds import (
     help="Set scanpy verbosity",
 )
 @click.option(
-    "--default_njobs",
+    "--njobs",
     type=click.INT,
     default=-1,
-    help="Set scanpy default number of jobs",
+    help="Set scanpy default number of jobs/CPUs, defaults to all available",
 )
 @click.version_option(
     version="0.2.0",
     prog_name="scanpy",
 )
-def cli(debug=False, verbosity=3):
+def cli(debug=False, verbosity=3, njobs=-1):
     """
     Command line interface to [scanpy](https://github.com/theislab/scanpy)
     """
@@ -77,7 +77,7 @@ def cli(debug=False, verbosity=3):
     )
     logging.debug("debugging")
     sc.settings.verbosity = verbosity
-    sc.settings.n_jobs = default_njobs
+    sc.settings.n_jobs = njobs
     return 0
 
 

--- a/scanpy_scripts/cli.py
+++ b/scanpy_scripts/cli.py
@@ -56,14 +56,14 @@ from .cmds import (
 @click.option(
     "--njobs",
     type=click.INT,
-    default=-1,
+    default=1,
     help="Set scanpy default number of jobs/CPUs, defaults to all available",
 )
 @click.version_option(
     version="0.2.0",
     prog_name="scanpy",
 )
-def cli(debug=False, verbosity=3, njobs=-1):
+def cli(debug=False, verbosity=3, njobs=1):
     """
     Command line interface to [scanpy](https://github.com/theislab/scanpy)
     """


### PR DESCRIPTION
Add a `scanpy-cli` option to set the default number of jobs/CPUs that scanpy uses, for parallel computing.